### PR TITLE
Don't treat orgs as URL parameter

### DIFF
--- a/application/controllers/campaign.php
+++ b/application/controllers/campaign.php
@@ -55,6 +55,10 @@ class Campaign extends CI_Controller
         $harvest = (!empty($harvest)) ? $harvest : $this->input->get('harvest', TRUE);
         $from_export = (!empty($from_export)) ? $from_export : $this->input->get('from_export', TRUE);
 
+        if (!$orgs) {
+          show_error('Invalid orgs parameter, cannot be empty', 400);
+          return
+        }
 
         $row_total = 100;
         $row_count = 0;

--- a/application/models/campaign_model.php
+++ b/application/models/campaign_model.php
@@ -2446,30 +2446,10 @@ class campaign_model extends CI_Model
             $filter .= "AND%20-harvest_source_id:[''%20TO%20*]";
         }
 
-        if (strpos($orgs, 'http://') !== false) {
-
-            $uri = $orgs;
-            $from_export = true;
-
-        } else {
-
-            $orgs = rawurlencode($orgs);
-            $query = $filter . "-type:harvest%20AND%20organization:(" . $orgs . ")&rows=" . $rows . '&start=' . $offset;
-            $uri = 'http://catalog.data.gov/api/3/action/package_search?q=' . $query;
-            $from_export = false;
-        }
-
+        $orgs = rawurlencode($orgs);
+        $query = $filter . "-type:harvest%20AND%20organization:(" . $orgs . ")&rows=" . $rows . '&start=' . $offset;
+        $uri = 'http://catalog.data.gov/api/3/action/package_search?q=' . $query;
         $datagov_json = curl_from_json($uri, false);
-
-        if ($from_export) {
-
-            $object_shim = new stdClass();
-            $object_shim->result = new stdClass();
-            $object_shim->result->count = count($datagov_json);
-            $object_shim->result->results = $datagov_json;
-
-            $datagov_json = $object_shim;
-        }
 
         if (empty($datagov_json)) return false;
 


### PR DESCRIPTION
For convert/csv tools, don't treat orgs as a URL parameter to avoid SSRF. Can't
find any documentation on why this was implemented in the first place.