### PR TITLE
Move private method to helper

### DIFF
--- a/application/controllers/campaign.php
+++ b/application/controllers/campaign.php
@@ -917,7 +917,7 @@ class Campaign extends CI_Controller
                         $expected_datajson_url = urldecode($url_override);
                     }
 
-                    $expected_datajson_url = $this->campaign->filter_remote_url($expected_datajson_url);
+                    $expected_datajson_url = filter_remote_url($expected_datajson_url);
                     if ($expected_datajson_url === false) {
                       show_error('Not valid data.json URL.', 400);
                       return;

--- a/application/helpers/api_helper.php
+++ b/application/helpers/api_helper.php
@@ -305,6 +305,56 @@ function filter_json( $source_datajson, $dataset_array = false ) {
 }
 
 
+function filter_remote_url($url, $allowed_schemes = array('http', 'https')) {
+    $url = filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED | FILTER_FLAG_PATH_REQUIRED);
+    // ban non http/https:
+    $scheme = parse_url($url, PHP_URL_SCHEME);
+    if ($url && !in_array($scheme, $allowed_schemes)) {
+        $url = false;
+    }
+
+    // ban localhost/portscan/ssrf
+
+    if ($url) {
+
+        $host = parse_url($url, PHP_URL_HOST);
+        /* We should check if host is IP first*/
+        if (filter_var($host, FILTER_VALIDATE_IP))// is ip
+        {
+            $url = false;
+        }
+        /*We should check if it is a hostname - resolving url*/
+        else
+        {
+            // If record resolved
+            $resolved = dns_get_record($host, DNS_A + DNS_AAAA);
+            if ($resolved)
+            {
+                // We should read the array of A and AAAA records, and check them against private ranges
+                for ($i=0; $i < count($resolved); $i++)
+                {
+                    if ($resolved[$i]["type"] === "A")
+                    if (!filter_var($resolved[$i]["ip"], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ))
+                        $url = false;
+                    if ($resolved[$i]["type"] === "AAAA")
+                    if (!filter_var($resolved[$i]["ipv6"], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ))
+                        $url = false;
+                }
+
+            }
+            else
+                $url = false;
+        }
+
+
+    }
+    // filter xss
+    if ($url && function_exists('xss_clean')) {
+        $url = xss_clean($url);
+    }
+    return $url;
+}
+
 
 function linkToAnchor($text) {
 
@@ -367,8 +417,5 @@ function prettyPrint( $json )
 
     return $result;
 }
-
-
-
 
 ?>

--- a/application/models/campaign_model.php
+++ b/application/models/campaign_model.php
@@ -876,65 +876,14 @@ class campaign_model extends CI_Model
         }
     }
 
-    private function filter_remote_url($url, $allowed_schemes = array('http', 'https'))
-    {
-        $url = filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED | FILTER_FLAG_PATH_REQUIRED);
-        // ban non http/https:
-        $scheme = parse_url($url, PHP_URL_SCHEME);
-        if ($url && !in_array($scheme, $allowed_schemes)) {
-            $url = false;
-        }
-
-        // ban localhost/portscan/ssrf
-
-        if ($url) {
-
-            $host = parse_url($url, PHP_URL_HOST);
-            /* We should check if host is IP first*/
-            if (filter_var($host, FILTER_VALIDATE_IP))// is ip
-            {
-                $url = false;
-            }
-            /*We should check if it is a hostname - resolving url*/
-            else
-            {
-                // If record resolved
-                $resolved = dns_get_record($host, DNS_A + DNS_AAAA);
-                if ($resolved)
-                {
-                    // We should read the array of A and AAAA records, and check them against private ranges
-                    for ($i=0; $i < count($resolved); $i++)
-                    {
-                        if ($resolved[$i]["type"] === "A")
-                        if (!filter_var($resolved[$i]["ip"], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ))
-                            $url = false;
-                        if ($resolved[$i]["type"] === "AAAA")
-                        if (!filter_var($resolved[$i]["ipv6"], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ))
-                            $url = false;
-                    }
-
-                }
-                else
-                    $url = false;
-            }
-
-
-        }
-        // filter xss
-        if ($url && function_exists('xss_clean')) {
-            $url = xss_clean($url);
-        }
-        return $url;
-    }
-
     public function validate_datajson($datajson_url = null, $datajson = null, $headers = null, $schema = null, $return_source = false, $quality = false, $component = null)
     {
-        $datajson_url = $this->filter_remote_url($datajson_url);
+        $datajson_url = filter_remote_url($datajson_url);
 
         if ($datajson_url) {
             $datajson_header = ($headers) ? $headers : $this->campaign->uri_header($datajson_url);
 
-            if (!isset($datajson_header['url']) || !$this->filter_remote_url($datajson_header['url'])) {
+            if (!isset($datajson_header['url']) || !filter_remote_url($datajson_header['url'])) {
                 $datajson_url = false;
             }
         }


### PR DESCRIPTION
This is a followup to #181 which was an incomplete fix. The `filter_remote_url` method is private and so cannot be called from the controller. This moves the method to the api helper, which is more appropriate since the method is really a utility function, not specific to the campaign model.