### PR TITLE
Add omb-monitored offices to crawls and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,28 +19,33 @@ In addition to the web interface, there's also a Command Line Interface to manag
 
 From the root of the application, you can update the status of agencies using a few different options on the `campaign` controller. The syntax is:
 
-`$ php index.php campaign status [id] [component]`
+`$ php public/index.php campaign status [id] [component]`
 
 If you wanted to update all components (data.json, digitalstrategy.json, /data) for all agencies, you'd run this command:
 
-`$ php index.php campaign status all all`
+`$ php public/index.php campaign status all all`
 
 If you just wanted to update the data.json status for CFO Act agencies you'd run:
 
-`$ php index.php campaign status cfo-act datajson`
+`$ php public/index.php campaign status cfo-act datajson`
+
+If you just wanted to update the data.json status for agencies being monitored by the OMB you'd run:
+
+`$ php public/index.php campaign status omb-monitored datajson`
 
 If you just wanted to update the digitalstrategy.json status for the Department of Agriculture you'd run:
 
-`$ php index.php campaign status 49015 digitalstrategy`
+`$ php public/index.php campaign status 49015 digitalstrategy`
 
-The options for [id] are: `all`,`cfo-act`, or the ID provided by the [USA.gov Federal Agency Directory API](http://www.usa.gov/About/developer-resources/federal-agency-directory/)
+The options for [id] are: `all`,`cfo-act`, `omb-monitored`, or the ID provided by the [USA.gov Federal Agency Directory API](http://www.usa.gov/About/developer-resources/federal-agency-directory/)
 
-The options for [component] are: `all`, `datajson`, `datapage`, `digitalstrategy`, `download`. 
+The options for [component] are: `all`, `datajson`, `datapage`, `digitalstrategy`, `download`, `full-scan`. 
 
 * The `datajson` component captures the basic characteristics of a request to an agency's data.json file (like whether it returns an HTTP 200) and then attempts to parse the file, validate against the schema, and provide other reporting metrics like the number of datasets listed. 
 * The `digitalstrategy` component captures the basic characteristics of a request to an agency's digitalstrategy.json file (like whether it returns an HTTP 200) 
 * The `datapage` component captures the basic characteristics of a request to an agency's /data page (like whether it returns an HTTP 200)
 * The `download` component downloads an archive of the data.json and digitalstrategy.json files
+* The `full-scan` component does further validation based on the content of the response
 * As you'd expect, `all` does all of these things at once. 
 
 ## Development
@@ -160,8 +165,8 @@ The agency hierarchy is designed to be populated from the `contacts` API at http
 following steps no longer work:
 
 > * Federal agencies were seeded using the [USA.gov Federal Agency Directory API](http://www.usa.gov/About/developer-resources/federal-agency-directory/) and the IDs provided by that resource are used as the primary IDs on this dashboard. 
-> * First populate the top of the agency hierarchy: `$ php index.php import`
-> * Second, populate all the subagencies: `$ php index.php import children`
+> * First populate the top of the agency hierarchy: `$ php public/index.php import`
+> * Second, populate all the subagencies: `$ php public/index.php import children`
 > * If you have an empty database `offices` table in the database, you'll also want to seed it with agency data by running the import script (`/application/controllers/import.php`) from a command line. You'll also need to temporarily change the `import_active` option in config.php to `true`
 
 

--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -69,7 +69,7 @@ $config['migration_auto_latest'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 6;
+$config['migration_version'] = 7;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Campaign.php
+++ b/application/controllers/Campaign.php
@@ -711,7 +711,7 @@ class Campaign extends CI_Controller
         $this->db->select('*');
         $this->db->from('offices');
         $this->db->join('datagov_campaign', 'datagov_campaign.office_id = offices.id', 'left');
-        $this->db->where('offices.cfo_act_agency', 'true');
+        $this->db->where('offices.omb_monitored', 'true');
         $this->db->where('offices.no_parent', 'true');
 
         if (!empty($id) && $id != 'all') {

--- a/application/controllers/Campaign.php
+++ b/application/controllers/Campaign.php
@@ -735,7 +735,7 @@ class Campaign extends CI_Controller
 
 
     /*
-    $id can be all, cfo-act, or a specific id
+    $id can be all, cfo-act, omb-monitored, or a specific id
     $component can be full-scan, all, datajson, datapage, digitalstrategy, download
     */
     public function status($id = null, $component = null, $selected_milestone = null, $url_override = null)
@@ -768,6 +768,8 @@ class Campaign extends CI_Controller
         // Filter for certain offices
         if ($id == 'cfo-act') {
             $this->db->where('cfo_act_agency', 'true');
+        } else if ($id == 'omb-monitored') {
+            $this->db->where('omb_monitored', 'true');
         }
 
         if (is_numeric($id)) {

--- a/application/controllers/Offices.php
+++ b/application/controllers/Offices.php
@@ -52,6 +52,7 @@ class Offices extends CI_Controller {
 
 		$view_data = array();
 
+		// Get all the CFO Act offices
 		$this->db->select('*');
 		$this->db->from('offices');
 		$this->db->join('datagov_campaign', 'datagov_campaign.office_id = offices.id', 'left');
@@ -67,6 +68,24 @@ class Offices extends CI_Controller {
 			$query->free_result();
 		}
 
+		// Get all the non-CFO Act agencies that are monitored by OMB
+		$this->db->select('*');
+		$this->db->from('offices');
+		$this->db->join('datagov_campaign', 'datagov_campaign.office_id = offices.id', 'left');
+		$this->db->where('datagov_campaign.milestone', $milestone->selected_milestone);
+		$this->db->where('offices.cfo_act_agency', 'false');
+		$this->db->where('offices.omb_monitored', 'true');
+		$this->db->where('offices.no_parent', 'true');
+		$this->db->where("(datagov_campaign.crawl_status IS NULL OR datagov_campaign.crawl_status = '$crawl_status_filter')");
+		$this->db->order_by("offices.name", "asc");
+		$query = $this->db->get();
+
+		if ($query->num_rows() > 0) {
+			$view_data['omb_monitored_offices'] = $query->result();
+			$query->free_result();
+		}
+
+		// Show other offices, divided by executive and independents
 		if ($this->config->item('show_all_offices') || $show_all_offices) {
 
 			$this->db->select('*');
@@ -74,6 +93,7 @@ class Offices extends CI_Controller {
 			$this->db->join('datagov_campaign', 'datagov_campaign.office_id = offices.id', 'left');
 			$this->db->where('datagov_campaign.milestone', $milestone->selected_milestone);
 			$this->db->where('offices.cfo_act_agency', 'false');
+			$this->db->where('offices.omb_monitored', 'false');
 			$this->db->where('offices.reporting_authority_type', 'executive');
 			$this->db->where('offices.no_parent', 'true');
 			$this->db->where("(datagov_campaign.crawl_status IS NULL OR datagov_campaign.crawl_status = '$crawl_status_filter')");
@@ -90,6 +110,7 @@ class Offices extends CI_Controller {
 			$this->db->join('datagov_campaign', 'datagov_campaign.office_id = offices.id', 'left');
 			$this->db->where('datagov_campaign.milestone', $milestone->selected_milestone);
 			$this->db->where('offices.cfo_act_agency', 'false');
+			$this->db->where('offices.omb_monitored', 'false');
 			$this->db->where('offices.reporting_authority_type', 'independent');
 			$this->db->where('offices.no_parent', 'true');
 			$this->db->where("(datagov_campaign.crawl_status IS NULL OR datagov_campaign.crawl_status = '$crawl_status_filter')");

--- a/application/migrations/007_add_omb_monitored_flag.php
+++ b/application/migrations/007_add_omb_monitored_flag.php
@@ -1,0 +1,81 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_add_omb_monitored_flag extends CI_Migration
+{
+
+    public function up()
+    {
+        // Add a column to indicate whether the office is one that the OMB is explicitly monitoring
+        $this->db->query("ALTER TABLE `offices` ADD `omb_monitored` varchar(256) CHARACTER SET latin1 DEFAULT 'FALSE' AFTER `cfo_act_agency`;");
+
+        // OMB wants to monitor all CFO Act agencies
+        $this->db->query("UPDATE offices SET omb_monitored = 'TRUE' WHERE cfo_act_agency = 'TRUE'");
+
+        // OMB wants to monitor these offices (for which there is no existing DB entry)
+        $this->db->query("INSERT INTO offices
+            (id, name, abbreviation, url, notes, no_parent, parent_office_id, reporting_authority_type, cfo_act_agency, omb_monitored) VALUES
+            (80000, 'District of Columbia Courts', 'DCC', 'https://www.dccourts.gov/', '', 'TRUE', 0, 'independent', 'FALSE', 'TRUE'),
+            (80001, 'Public Defender Service of the District of Columbia', 'PDSDC', 'https://www.pdsdc.org/', '', 'TRUE', 0, 'independent', 'FALSE', 'TRUE'),
+            (80002, 'US Agency for Global Media', 'USAGM', 'https://www.usagm.gov/', '', 'TRUE', 0, 'independent', 'FALSE', 'TRUE')
+            ");
+
+        // OMB also wants to monitor these offices, already in the DB
+        $this->db->query("UPDATE offices SET omb_monitored = 'TRUE' WHERE name IN (
+            'Administrative Conference of the United States',
+            'American Battle Monuments Commission',
+            'Commission on Civil Rights',
+            'Consumer Financial Protection Bureau',
+            'Consumer Product Safety Commission',
+            'Corporation for National and Community Service',
+            'Court Services and Offender Supervision Agency for the District of Columbia',
+            'District of Columbia Courts',
+            'Equal Employment Opportunity Commission',
+            'Export-Import Bank of the United States',
+            'Farm Credit Administration',
+            'Farm Credit System Insurance Corporation ',
+            'Federal Communications Commission',
+            'Federal Deposit Insurance Corporation',
+            'Federal Energy Regulatory Commission',
+            'Federal Housing Finance Agency',
+            'Federal Maritime Commission',
+            'Federal Mediation and Conciliation Service',
+            'Federal Reserve System',
+            'Federal Retirement Thrift Investment Board',
+            'Federal Trade Commission',
+            'Inter-American Foundation',
+            'Merit Systems Protection Board',
+            'Millennium Challenge Corporation',
+            'Morris K. Udall and Stewart L. Udall Foundation',
+            'National Capital Planning Commission',
+            'National Credit Union Administration',
+            'National Endowment for the Arts',
+            'National Endowment for the Humanities',
+            'National Mediation Board',
+            'National Transportation Safety Board',
+            'Nuclear Waste Technical Review Board',
+            'Occupational Safety and Health Review Commission',
+            'Office of Government Ethics',
+            'Office of the Comptroller of the Currency',
+            'Peace Corps',
+            'Pension Benefit Guaranty Corporation',
+            'Presidio Trust',
+            'Public Defender Service of the District of Columbia',
+            'Railroad Retirement Board',
+            'Selective Service System',
+            'Surface Transportation Board',
+            'U.S. Access Board',
+            'U.S. Commission of Fine Arts',
+            'U.S. Commodity Futures Trading Commission',
+            'U.S. International Trade Commission',
+            'Office of Special Counsel',
+            'U.S. Trade and Development Agency',
+            'US Agency for Global Media')
+            ");
+
+    }
+}
+
+
+

--- a/application/tests/controllers/Offices_test.php
+++ b/application/tests/controllers/Offices_test.php
@@ -1,7 +1,48 @@
 <?php
 
-class OfficesTest extends TestCase
+class OfficesTest extends DbTestCase
 {
+
+    /*
+        In a test environment, no crawls have completed, so there's no
+        information in the datagov_campaign table. This isn't the state in a
+        normal ongoing deployment, and the app logic doesn't show output in some
+        cases unless there are entries. So for some tests, we need to
+        prepopulate that table for the current milestone.
+    */
+    public function seedCampaignFixture() {
+
+        $CI =& get_instance();
+
+        // We need to be able to use milestone logic to find the current
+        // milestone. (There might be a better way to do this that doesn't
+        // loading up so much model code.)
+        $CI->load->model('campaign_model', 'campaign');
+        $milestones = $CI->campaign->milestones_model();
+        $milestone = $CI->campaign->milestone_filter('', $milestones);
+        $milestone = $milestone->current;
+
+        // Get a list of the IDs for all the monitored offices
+        $CI->db->select('offices.id');
+		$CI->db->from('offices');
+		$CI->db->where('offices.omb_monitored', 'true');
+        $query = $CI->db->get();
+        $results = $query->result();
+        $query->free_result();
+
+        // Ensure there's one row in the datagov_campaign table for the current
+        // milestone for each office we're monitoring.
+        foreach ($results as $agency) {
+            $this->hasInDatabase('datagov_campaign',
+                array('office_id' => $agency->id,
+                      'milestone' => $milestone,
+                      'crawl_status' => 'current'));
+        }
+
+        // All the entries added above via hasInDatabase() get removed
+        // automatically during DbTestCase::tearDown()
+    }
+
 
     public function testOfficeDetailsPageIsValidWithoutCrawls() {
         // We can improve this test by explicitly ensuring that there are no crawls present first,
@@ -10,7 +51,11 @@ class OfficesTest extends TestCase
         $this->assertResponseCode(200);
     }
 
-    public function testOfficesListIncludesOmbMonitoredOffices() {
+    // Test that OMB-monitored offices are listed in a simple request
+    public function testOfficeListIncludesOmbMonitoredOffices() {
+
+        $this->seedCampaignFixture();
+
         $output = $this->request('GET', 'offices');
         $this->assertResponseCode(200);
         $this->assertContains('<td>Other OMB-Monitored Agencies</td>', $output);

--- a/application/tests/controllers/Offices_test.php
+++ b/application/tests/controllers/Offices_test.php
@@ -10,6 +10,12 @@ class OfficesTest extends TestCase
         $this->assertResponseCode(200);
     }
 
+    public function testOfficesListIncludesOmbMonitoredOffices() {
+        $output = $this->request('GET', 'offices');
+        $this->assertResponseCode(200);
+        $this->assertContains('<td>Other OMB-Monitored Agencies</td>', $output);
+    }
+
     /**
      * These are strapping tests that just assert that no PHP errors are encountered on clicks of nav links
      * @dataProvider badMilestoneProvider

--- a/application/tests/migrations/Migrations_test.php
+++ b/application/tests/migrations/Migrations_test.php
@@ -1,0 +1,116 @@
+<?php
+
+class MigrationsTest extends TestCase
+{
+
+    /**
+     * These are strapping tests that just assert that no PHP errors are encountered on clicks of nav links
+     */
+    public function testOmbMonitoredOfficesArePresentAndFlaggedInDatabase()
+  	{
+        // Get an array of the names of all the OMB-monitored Offices in the DB, sorted
+        $CI =& get_instance();
+        $CI->load->database();
+        $CI->db->select('*');
+		$CI->db->from('offices');
+		$CI->db->where('offices.omb_monitored', 'true');
+		$CI->db->order_by("offices.name", "asc");
+        $query = $CI->db->get();
+        $results = $query->result();
+        $query->free_result();
+
+        $agencies = [];
+        foreach ($results as $agency) {
+            $agencies[] = $agency->name;
+        }
+        sort($agencies);
+
+        // Set up an explicit list of the agencies that OMB is monitoring for comparison
+        $cfo_act_agencies = [
+            'Department of Agriculture',
+            'Department of Commerce',
+            'Department of Defense',
+            'Department of Education',
+            'Department of Energy',
+            'Department of Health and Human Services',
+            'Department of Homeland Security',
+            'Department of Housing and Urban Development',
+            'Department of Justice',
+            'Department of Labor',
+            'Department of State',
+            'Department of the Interior',
+            'Department of the Treasury',
+            'Department of Transportation',
+            'Department of Veterans Affairs',
+            'Environmental Protection Agency',
+            'General Services Administration',
+            'National Aeronautics and Space Administration',
+            'National Science Foundation',
+            'Nuclear Regulatory Commission',
+            'Office of Personnel Management',
+            'Small Business Administration',
+            'Social Security Administration',
+            'U.S. Agency for International Development'
+        ];
+
+        $other_agencies = [
+            'Administrative Conference of the United States',
+            'American Battle Monuments Commission',
+            'Commission on Civil Rights',
+            'Consumer Financial Protection Bureau',
+            'Consumer Product Safety Commission',
+            'Corporation for National and Community Service',
+            'Court Services and Offender Supervision Agency for the District of Columbia',
+            'District of Columbia Courts',
+            'Equal Employment Opportunity Commission',
+            'Export-Import Bank of the United States',
+            'Farm Credit Administration',
+            'Farm Credit System Insurance Corporation',
+            'Federal Communications Commission',
+            'Federal Deposit Insurance Corporation',
+            'Federal Energy Regulatory Commission',
+            'Federal Housing Finance Agency',
+            'Federal Maritime Commission',
+            'Federal Mediation and Conciliation Service',
+            'Federal Reserve System',
+            'Federal Retirement Thrift Investment Board',
+            'Federal Trade Commission',
+            'Inter-American Foundation',
+            'Merit Systems Protection Board',
+            'Millennium Challenge Corporation',
+            'Morris K. Udall and Stewart L. Udall Foundation',
+            'National Capital Planning Commission',
+            'National Credit Union Administration',
+            'National Endowment for the Arts',
+            'National Endowment for the Humanities',
+            'National Mediation Board',
+            'National Transportation Safety Board',
+            'Nuclear Waste Technical Review Board',
+            'Occupational Safety and Health Review Commission',
+            'Office of Government Ethics',
+            'Office of Special Counsel',
+            'Office of the Comptroller of the Currency',
+            'Peace Corps',
+            'Pension Benefit Guaranty Corporation',
+            'Presidio Trust',
+            'Public Defender Service of the District of Columbia',
+            'Railroad Retirement Board',
+            'Selective Service System',
+            'Surface Transportation Board',
+            'U.S. Access Board',
+            'U.S. Commission of Fine Arts',
+            'U.S. Commodity Futures Trading Commission',
+            'U.S. International Trade Commission',
+            'U.S. Trade and Development Agency',
+            'US Agency for Global Media'
+        ];
+
+        $expected_agencies = array_merge($cfo_act_agencies, $other_agencies);
+        sort($expected_agencies);
+
+        // Check that the list from the DB matches the expected list
+        $this->assertEquals($agencies, $expected_agencies);
+
+   }
+
+}

--- a/application/views/office_list.php
+++ b/application/views/office_list.php
@@ -79,6 +79,18 @@ if($show_all_fields) {
 
 			}
 
+			if(!empty($omb_monitored_offices)) {
+
+        if($show_all_fields) {
+          status_table_full('Other OMB-Monitored Agencies', $omb_monitored_offices, $tracker, $config, $milestone->selected_milestone, $milestone->specified);
+        } elseif ($show_qa_fields) {
+          status_table_qa('Other OMB-Monitored Agencies', $omb_monitored_offices, $tracker, $config, $section_breakdown, $milestone);
+        } else {
+          status_table('Other OMB-Monitored Agencies', $omb_monitored_offices, $tracker, $config, $section_breakdown, $milestone);
+        }
+
+			}
+
 			if(!empty($executive_offices)) {
 				status_table('Other Offices Reporting to the White House', $executive_offices, $config, $milestone->selected_milestone, $milestone->specified);
 			}

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
                 "reference": "1.1.0"
             }
         }
+    },
+    {
+        "type": "vcs",
+        "url": "https://github.com/mogul/ci-phpunit-test"
     }],
     "require": {
         "php": ">=7.3.0",
@@ -36,7 +40,7 @@
     "require-dev": {
         "mikey179/vfsstream": "1.1.*",
         "phpunit/phpunit": "~7.5",
-        "kenjis/ci-phpunit-test": "master@dev"
+        "kenjis/ci-phpunit-test": "dev-patch-2"
     },
     "scripts": {
         "test": "./vendor/bin/phpunit --no-coverage --testdox -c application/tests"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45f86364e2c8e50abc898c430c4aaa22",
+    "content-hash": "7e212395b04d81b6eb47da87f69437fa",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.132.4",
+            "version": "3.133.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "5dcf2fb87a3cde87a5fa0b9df03b8688dcfc4f19"
+                "reference": "cd7bd2fdd159146ef6c7eeb90b73fae4fd11da57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5dcf2fb87a3cde87a5fa0b9df03b8688dcfc4f19",
-                "reference": "5dcf2fb87a3cde87a5fa0b9df03b8688dcfc4f19",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/cd7bd2fdd159146ef6c7eeb90b73fae4fd11da57",
+                "reference": "cd7bd2fdd159146ef6c7eeb90b73fae4fd11da57",
                 "shasum": ""
             },
             "require": {
@@ -88,7 +88,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2020-01-13T19:11:21+00:00"
+            "time": "2020-01-24T19:11:35+00:00"
         },
         {
             "name": "codeigniter/framework",
@@ -1083,16 +1083,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "6911d432edd5b50822986604fd5a5be3af856d30"
+                "reference": "4d3979f54472637169080f802dc82197e21fdcce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/6911d432edd5b50822986604fd5a5be3af856d30",
-                "reference": "6911d432edd5b50822986604fd5a5be3af856d30",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4d3979f54472637169080f802dc82197e21fdcce",
+                "reference": "4d3979f54472637169080f802dc82197e21fdcce",
                 "shasum": ""
             },
             "require": {
@@ -1143,20 +1143,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-18T12:00:29+00:00"
+            "time": "2020-01-04T13:00:46+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5c4c1db977dc70bb3250e1308d3e8c6341aa38f5"
+                "reference": "89c3fd5c299b940333bc6fe9f1b8db1b0912c759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5c4c1db977dc70bb3250e1308d3e8c6341aa38f5",
-                "reference": "5c4c1db977dc70bb3250e1308d3e8c6341aa38f5",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/89c3fd5c299b940333bc6fe9f1b8db1b0912c759",
+                "reference": "89c3fd5c299b940333bc6fe9f1b8db1b0912c759",
                 "shasum": ""
             },
             "require": {
@@ -1199,20 +1199,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-16T14:46:54+00:00"
+            "time": "2020-01-08T17:29:02+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "79b0358207a3571cc3af02a57d0321927921f539"
+                "reference": "6faf589e1f6af78692aed3ab6b3c336c58d5d83c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/79b0358207a3571cc3af02a57d0321927921f539",
-                "reference": "79b0358207a3571cc3af02a57d0321927921f539",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/6faf589e1f6af78692aed3ab6b3c336c58d5d83c",
+                "reference": "6faf589e1f6af78692aed3ab6b3c336c58d5d83c",
                 "shasum": ""
             },
             "require": {
@@ -1272,20 +1272,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-19T16:00:02+00:00"
+            "time": "2020-01-21T07:39:36+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "6d7d7712a6ff5215ec26215672293b154f1db8c1"
+                "reference": "a59789092e40ad08465dc2cdc55651be503d0d5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/6d7d7712a6ff5215ec26215672293b154f1db8c1",
-                "reference": "6d7d7712a6ff5215ec26215672293b154f1db8c1",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/a59789092e40ad08465dc2cdc55651be503d0d5a",
+                "reference": "a59789092e40ad08465dc2cdc55651be503d0d5a",
                 "shasum": ""
             },
             "require": {
@@ -1328,20 +1328,20 @@
             ],
             "description": "Symfony ErrorHandler Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-16T14:46:54+00:00"
+            "time": "2020-01-08T17:29:02+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f"
+                "reference": "9e3de195e5bc301704dd6915df55892f6dfc208b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b3c3068a72623287550fe20b84a2b01dcba2686f",
-                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9e3de195e5bc301704dd6915df55892f6dfc208b",
+                "reference": "9e3de195e5bc301704dd6915df55892f6dfc208b",
                 "shasum": ""
             },
             "require": {
@@ -1398,7 +1398,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-28T13:33:56+00:00"
+            "time": "2020-01-10T21:54:01+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1460,16 +1460,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.0.2",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "1d71f670bc5a07b9ccc97dc44f932177a322d4e6"
+                "reference": "3afadc0f57cd74f86379d073e694b0f2cda2a88c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/1d71f670bc5a07b9ccc97dc44f932177a322d4e6",
-                "reference": "1d71f670bc5a07b9ccc97dc44f932177a322d4e6",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3afadc0f57cd74f86379d073e694b0f2cda2a88c",
+                "reference": "3afadc0f57cd74f86379d073e694b0f2cda2a88c",
                 "shasum": ""
             },
             "require": {
@@ -1506,20 +1506,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-26T23:25:11+00:00"
+            "time": "2020-01-21T08:40:24+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "fcae1cff5b57b2a9c3aabefeb1527678705ddb62"
+                "reference": "c33998709f3fe9b8e27e0277535b07fbf6fde37a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fcae1cff5b57b2a9c3aabefeb1527678705ddb62",
-                "reference": "fcae1cff5b57b2a9c3aabefeb1527678705ddb62",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/c33998709f3fe9b8e27e0277535b07fbf6fde37a",
+                "reference": "c33998709f3fe9b8e27e0277535b07fbf6fde37a",
                 "shasum": ""
             },
             "require": {
@@ -1561,20 +1561,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-19T15:57:49+00:00"
+            "time": "2020-01-04T13:00:46+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "fe310d2e95cd4c356836c8ecb0895a46d97fede2"
+                "reference": "16f2aa3c54b08483fba5375938f60b1ff83b6bd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fe310d2e95cd4c356836c8ecb0895a46d97fede2",
-                "reference": "fe310d2e95cd4c356836c8ecb0895a46d97fede2",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/16f2aa3c54b08483fba5375938f60b1ff83b6bd2",
+                "reference": "16f2aa3c54b08483fba5375938f60b1ff83b6bd2",
                 "shasum": ""
             },
             "require": {
@@ -1651,20 +1651,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-19T16:23:40+00:00"
+            "time": "2020-01-21T13:23:17+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.0.2",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "0e6a4ced216e49d457eddcefb61132173a876d79"
+                "reference": "2a3c7fee1f1a0961fa9cf360d5da553d05095e59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/0e6a4ced216e49d457eddcefb61132173a876d79",
-                "reference": "0e6a4ced216e49d457eddcefb61132173a876d79",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/2a3c7fee1f1a0961fa9cf360d5da553d05095e59",
+                "reference": "2a3c7fee1f1a0961fa9cf360d5da553d05095e59",
                 "shasum": ""
             },
             "require": {
@@ -1713,7 +1713,7 @@
                 "mime",
                 "mime-type"
             ],
-            "time": "2019-11-30T14:12:50+00:00"
+            "time": "2020-01-04T14:08:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2009,16 +2009,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "628bcafae1b2043969378dcfbf9c196539a38722"
+                "reference": "7bf4e38573728e317b926ca4482ad30470d0e86a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/628bcafae1b2043969378dcfbf9c196539a38722",
-                "reference": "628bcafae1b2043969378dcfbf9c196539a38722",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/7bf4e38573728e317b926ca4482ad30470d0e86a",
+                "reference": "7bf4e38573728e317b926ca4482ad30470d0e86a",
                 "shasum": ""
             },
             "require": {
@@ -2081,7 +2081,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-12-12T12:53:52+00:00"
+            "time": "2020-01-08T17:29:02+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2143,16 +2143,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.0.2",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "d7bc61d5d335fa9b1b91e14bb16861e8ca50f53a"
+                "reference": "ccb1be566ae15f790020f917f06d1da0b04fe47b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/d7bc61d5d335fa9b1b91e14bb16861e8ca50f53a",
-                "reference": "d7bc61d5d335fa9b1b91e14bb16861e8ca50f53a",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/ccb1be566ae15f790020f917f06d1da0b04fe47b",
+                "reference": "ccb1be566ae15f790020f917f06d1da0b04fe47b",
                 "shasum": ""
             },
             "require": {
@@ -2214,20 +2214,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-12-18T13:50:31+00:00"
+            "time": "2020-01-04T14:08:26+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a08832b974dd5fafe3085a66d41fe4c84bb2628c"
+                "reference": "cd014e425b3668220adb865f53bff64b3ad21767"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a08832b974dd5fafe3085a66d41fe4c84bb2628c",
-                "reference": "a08832b974dd5fafe3085a66d41fe4c84bb2628c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cd014e425b3668220adb865f53bff64b3ad21767",
+                "reference": "cd014e425b3668220adb865f53bff64b3ad21767",
                 "shasum": ""
             },
             "require": {
@@ -2273,7 +2273,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-12-10T10:33:21+00:00"
+            "time": "2020-01-21T11:12:16+00:00"
         },
         {
             "name": "twig/extensions",
@@ -2598,16 +2598,16 @@
         },
         {
             "name": "kenjis/ci-phpunit-test",
-            "version": "dev-master",
+            "version": "dev-patch-2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/kenjis/ci-phpunit-test.git",
-                "reference": "f45b8eeb953dbfe6fdf0649b8e1c2a78bd337d05"
+                "url": "https://github.com/mogul/ci-phpunit-test.git",
+                "reference": "84c82b6cd957f36da4df356fdee8bf6cf921adbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kenjis/ci-phpunit-test/zipball/f45b8eeb953dbfe6fdf0649b8e1c2a78bd337d05",
-                "reference": "f45b8eeb953dbfe6fdf0649b8e1c2a78bd337d05",
+                "url": "https://api.github.com/repos/mogul/ci-phpunit-test/zipball/84c82b6cd957f36da4df356fdee8bf6cf921adbc",
+                "reference": "84c82b6cd957f36da4df356fdee8bf6cf921adbc",
                 "shasum": ""
             },
             "require": {
@@ -2620,7 +2620,6 @@
                     "dev-master": "1.0.x-dev"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -2639,7 +2638,11 @@
                 "test",
                 "unit testing"
             ],
-            "time": "2019-11-06T12:58:12+00:00"
+            "support": {
+                "forum": "http://forum.codeigniter.com/thread-61725.html",
+                "source": "https://github.com/mogul/ci-phpunit-test/tree/patch-2"
+            },
+            "time": "2020-01-29T03:22:11+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -2673,16 +2676,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/579bb7356d91f9456ccd505f24ca8b667966a0a7",
-                "reference": "579bb7356d91f9456ccd505f24ca8b667966a0a7",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -2717,28 +2720,29 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-12-15T19:12:40+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.5",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce"
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
-                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.5"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
+                "ircmaxell/php-yacc": "0.0.5",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -2746,7 +2750,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2768,7 +2772,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-02-28T20:30:58+00:00"
+            "time": "2019-11-08T13:50:10+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3025,24 +3029,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.10.1",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
-                "reference": "cbe1df668b3fe136bcc909126a0f529a78d4cbbc",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5 || ^3.2",
@@ -3084,7 +3088,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-12-22T21:05:45+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
Addresses https://github.com/GSA/datagov-deploy/issues/1193

Note that this branch depends on a fix for a problem in the upstream testing framework that I encountered. The branch is referring to [my fork that includes the fix](https://github.com/mogul/ci-phpunit-test/tree/patch-2) while [the PR with the fix](https://github.com/kenjis/ci-phpunit-test/pull/321) is pending. If that PR gets merged before this one, then I'll push a commit that reverts that composer.json change.