### PR TITLE
Revert upstream test framework fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,6 @@
                 "reference": "1.1.0"
             }
         }
-    },
-    {
-        "type": "vcs",
-        "url": "https://github.com/mogul/ci-phpunit-test"
     }],
     "require": {
         "php": ">=7.3.0",
@@ -40,7 +36,7 @@
     "require-dev": {
         "mikey179/vfsstream": "1.1.*",
         "phpunit/phpunit": "~7.5",
-        "kenjis/ci-phpunit-test": "dev-patch-2"
+        "kenjis/ci-phpunit-test": "master@dev"
     },
     "scripts": {
         "test": "./vendor/bin/phpunit --no-coverage --testdox -c application/tests"


### PR DESCRIPTION
This reverts the change in d0098bf4fb049be0e322b7446ac8c014afaf4213. Don't merge it until the [upstream PR](https://github.com/kenjis/ci-phpunit-test/pull/321) is merged.