### PR TITLE
Remove OMB reporting summaries

### DIFF
--- a/application/tests/controllers/Offices_test.php
+++ b/application/tests/controllers/Offices_test.php
@@ -36,7 +36,84 @@ class OfficesTest extends DbTestCase
             $this->hasInDatabase('datagov_campaign',
                 array('office_id' => $agency->id,
                       'milestone' => $milestone,
-                      'crawl_status' => 'current'));
+                      'crawl_status' => 'current',
+                      'datajson_status' => '{
+                        "url": "https:\/\/www.opm.gov\/data.json",
+                        "content_type": "application\/javascript",
+                        "http_code": 200,
+                        "header_size": 685,
+                        "request_size": 544,
+                        "filetime": 1533930113,
+                        "ssl_verify_result": 0,
+                        "redirect_count": 1,
+                        "total_time": 0.077116,
+                        "namelookup_time": 1.6e-5,
+                        "connect_time": 0.003334,
+                        "pretransfer_time": 0.013315,
+                        "size_upload": 0,
+                        "size_download": 0,
+                        "speed_download": 0,
+                        "speed_upload": 0,
+                        "download_content_length": 1437735,
+                        "upload_content_length": 0,
+                        "starttransfer_time": 0.064938,
+                        "redirect_time": 0.012125,
+                        "redirect_url": "",
+                        "primary_ip": "104.117.43.127",
+                        "certinfo": [],
+                        "primary_port": 443,
+                        "local_ip": "10.183.32.196",
+                        "local_port": 37664,
+                        "expected_url": "http:\/\/www.opm.gov\/data.json",
+                        "valid_json": true,
+                        "valid_schema": true,
+                        "total_records": 682,
+                        "schema_version": "federal-v1.1",
+                        "schema_errors": null,
+                        "qa": {
+                            "programCodes": [
+                                "027:000",
+                                "027:008",
+                                "027:002",
+                                "027:007",
+                                "027:005",
+                                "027:004",
+                                "027:006",
+                                "027:009"
+                            ],
+                            "bureauCodes": [
+                                "027:00"
+                            ],
+                            "accessLevel_public": 583,
+                            "accessLevel_restricted": 56,
+                            "accessLevel_nonpublic": 43,
+                            "accessURL_present": 478,
+                            "accessURL_total": 767,
+                            "API_total": 6,
+                            "API_public": 6,
+                            "API_restricted": 0,
+                            "API_nonpublic": 0,
+                            "collections_total": 32,
+                            "non_collection_total": 176,
+                            "validation_counts": {
+                                "http_5xx": 4,
+                                "http_4xx": 1,
+                                "http_3xx": 748,
+                                "http_2xx": 14,
+                                "http_0": 0,
+                                "pdf": 6,
+                                "html": 5,
+                                "format_mismatch": 1
+                            },
+                            "license_present": 682,
+                            "redaction_present": 0,
+                            "redaction_no_explanation": 0,
+                            "downloadURL_present": 473,
+                            "downloadURL_total": 539
+                        },
+                        "last_crawl": 1559363436,
+                        "error_count": 0
+                    }'));
         }
 
         // All the entries added above via hasInDatabase() get removed
@@ -56,9 +133,9 @@ class OfficesTest extends DbTestCase
 
         $this->seedCampaignFixture();
 
-        $output = $this->request('GET', 'offices');
+        $output = $this->request('GET', 'offices/qa');
         $this->assertResponseCode(200);
-        $this->assertContains('<td>Other OMB-Monitored Agencies</td>', $output);
+        $this->assertContains('<td>Other Agencies</td>', $output);
     }
 
     /**

--- a/application/tests/controllers/Offices_test.php
+++ b/application/tests/controllers/Offices_test.php
@@ -3,123 +3,174 @@
 class OfficesTest extends DbTestCase
 {
 
-    /*
-        In a test environment, no crawls have completed, so there's no
-        information in the datagov_campaign table. This isn't the state in a
-        normal ongoing deployment, and the app logic doesn't show output in some
-        cases unless there are entries. So for some tests, we need to
-        prepopulate that table for the current milestone.
-    */
-    public function seedCampaignFixture() {
+    public function seedOmbMonitoredOfficeCampaignFixtures() {
 
         $CI =& get_instance();
 
         // We need to be able to use milestone logic to find the current
         // milestone. (There might be a better way to do this that doesn't
-        // loading up so much model code.)
+        // require loading up so much model code.)
         $CI->load->model('campaign_model', 'campaign');
         $milestones = $CI->campaign->milestones_model();
         $milestone = $CI->campaign->milestone_filter('', $milestones);
         $milestone = $milestone->current;
 
-        // Get a list of the IDs for all the monitored offices
+        // Get a list of the IDs for all the OMB-monitored offices
         $CI->db->select('offices.id');
-		$CI->db->from('offices');
-		$CI->db->where('offices.omb_monitored', 'true');
+        $CI->db->from('offices');
+        $CI->db->where('offices.omb_monitored', 'true');
         $query = $CI->db->get();
         $results = $query->result();
         $query->free_result();
 
-        // Ensure there's one row in the datagov_campaign table for the current
-        // milestone for each office we're monitoring.
+        // Seed a campaign entry for each one
         foreach ($results as $agency) {
-            $this->hasInDatabase('datagov_campaign',
-                array('office_id' => $agency->id,
-                      'milestone' => $milestone,
-                      'crawl_status' => 'current',
-                      'datajson_status' => '{
-                        "url": "https:\/\/www.opm.gov\/data.json",
-                        "content_type": "application\/javascript",
-                        "http_code": 200,
-                        "header_size": 685,
-                        "request_size": 544,
-                        "filetime": 1533930113,
-                        "ssl_verify_result": 0,
-                        "redirect_count": 1,
-                        "total_time": 0.077116,
-                        "namelookup_time": 1.6e-5,
-                        "connect_time": 0.003334,
-                        "pretransfer_time": 0.013315,
-                        "size_upload": 0,
-                        "size_download": 0,
-                        "speed_download": 0,
-                        "speed_upload": 0,
-                        "download_content_length": 1437735,
-                        "upload_content_length": 0,
-                        "starttransfer_time": 0.064938,
-                        "redirect_time": 0.012125,
-                        "redirect_url": "",
-                        "primary_ip": "104.117.43.127",
-                        "certinfo": [],
-                        "primary_port": 443,
-                        "local_ip": "10.183.32.196",
-                        "local_port": 37664,
-                        "expected_url": "http:\/\/www.opm.gov\/data.json",
-                        "valid_json": true,
-                        "valid_schema": true,
-                        "total_records": 682,
-                        "schema_version": "federal-v1.1",
-                        "schema_errors": null,
-                        "qa": {
-                            "programCodes": [
-                                "027:000",
-                                "027:008",
-                                "027:002",
-                                "027:007",
-                                "027:005",
-                                "027:004",
-                                "027:006",
-                                "027:009"
-                            ],
-                            "bureauCodes": [
-                                "027:00"
-                            ],
-                            "accessLevel_public": 583,
-                            "accessLevel_restricted": 56,
-                            "accessLevel_nonpublic": 43,
-                            "accessURL_present": 478,
-                            "accessURL_total": 767,
-                            "API_total": 6,
-                            "API_public": 6,
-                            "API_restricted": 0,
-                            "API_nonpublic": 0,
-                            "collections_total": 32,
-                            "non_collection_total": 176,
-                            "validation_counts": {
-                                "http_5xx": 4,
-                                "http_4xx": 1,
-                                "http_3xx": 748,
-                                "http_2xx": 14,
-                                "http_0": 0,
-                                "pdf": 6,
-                                "html": 5,
-                                "format_mismatch": 1
-                            },
-                            "license_present": 682,
-                            "redaction_present": 0,
-                            "redaction_no_explanation": 0,
-                            "downloadURL_present": 473,
-                            "downloadURL_total": 539
-                        },
-                        "last_crawl": 1559363436,
-                        "error_count": 0
-                    }'));
+            $this->seedCampaignFixture($agency->id, $milestone, ($agency->id)%2);
         }
-
-        // All the entries added above via hasInDatabase() get removed
-        // automatically during DbTestCase::tearDown()
     }
 
+    public function getSuccessfulDataJSONStatus() {
+        // Valid/successful crawl
+        return '{
+        "url": "https:\/\/www.opm.gov\/data.json",
+        "content_type": "application\/javascript",
+        "http_code": 200,
+        "header_size": 685,
+        "request_size": 544,
+        "filetime": 1533930113,
+        "ssl_verify_result": 0,
+        "redirect_count": 1,
+        "total_time": 0.077116,
+        "namelookup_time": 1.6e-5,
+        "connect_time": 0.003334,
+        "pretransfer_time": 0.013315,
+        "size_upload": 0,
+        "size_download": 0,
+        "speed_download": 0,
+        "speed_upload": 0,
+        "download_content_length": 1437735,
+        "upload_content_length": 0,
+        "starttransfer_time": 0.064938,
+        "redirect_time": 0.012125,
+        "redirect_url": "",
+        "primary_ip": "104.117.43.127",
+        "certinfo": [],
+        "primary_port": 443,
+        "local_ip": "10.183.32.196",
+        "local_port": 37664,
+        "expected_url": "http:\/\/www.opm.gov\/data.json",
+        "valid_json": true,
+        "valid_schema": true,
+        "total_records": 682,
+        "schema_version": "federal-v1.1",
+        "schema_errors": null,
+        "qa": {
+            "programCodes": [
+                "027:000",
+                "027:008",
+                "027:002",
+                "027:007",
+                "027:005",
+                "027:004",
+                "027:006",
+                "027:009"
+            ],
+            "bureauCodes": [
+                "027:00"
+            ],
+            "accessLevel_public": 583,
+            "accessLevel_restricted": 56,
+            "accessLevel_nonpublic": 43,
+            "accessURL_present": 478,
+            "accessURL_total": 767,
+            "API_total": 6,
+            "API_public": 6,
+            "API_restricted": 0,
+            "API_nonpublic": 0,
+            "collections_total": 32,
+            "non_collection_total": 176,
+            "validation_counts": {
+                "http_5xx": 4,
+                "http_4xx": 1,
+                "http_3xx": 748,
+                "http_2xx": 14,
+                "http_0": 0,
+                "pdf": 6,
+                "html": 5,
+                "format_mismatch": 1
+            },
+            "license_present": 682,
+            "redaction_present": 0,
+            "redaction_no_explanation": 0,
+            "downloadURL_present": 473,
+            "downloadURL_total": 539
+        },
+        "last_crawl": 1559363436,
+        "error_count": 0
+        }';
+    }
+
+    public function getUnsuccessfulDataJSONStatus() {
+        // Invalid/unsuccessful crawl
+        return '{
+            "url": "https:\/\/www.justice.gov\/digitalstrategy\/data.json",
+            "content_type": "text\/html; charset=utf-8",
+            "http_code": 404,
+            "header_size": 1528,
+            "request_size": 468,
+            "filetime": 1575302256,
+            "ssl_verify_result": 0,
+            "redirect_count": 3,
+            "total_time": 1.092282,
+            "namelookup_time": 0.000103,
+            "connect_time": 0.14046500000000001,
+            "pretransfer_time": 0.457959,
+            "size_upload": 0,
+            "size_download": 0,
+            "speed_download": 0,
+            "speed_upload": 0,
+            "download_content_length": -1,
+            "upload_content_length": -1,
+            "starttransfer_time": 1.0921050000000001,
+            "redirect_time": 0.79269000000000001,
+            "redirect_url": "",
+            "primary_ip": "23.50.184.10",
+            "certinfo": [],
+            "primary_port": 443,
+            "local_ip": "10.183.32.234",
+            "local_port": 59426,
+            "http_version": 2,
+            "protocol": 2,
+            "ssl_verifyresult": 0,
+            "scheme": "HTTPS",
+            "expected_url": "http:\/\/www.usdoj.gov\/data.json",
+            "last_crawl": 1575325730,
+            "error_count": null,
+            "schema_errors": null
+            }';
+    }
+
+
+    /*
+        In a test environment, no crawls have completed, so there's no
+        information in the datagov_campaign table. This isn't the state in a
+        normal ongoing deployment, and the app logic doesn't show output in some
+        cases unless there are entries. So for some tests, we need to
+        prepopulate that table.
+
+        $milestone <= String date value like '2020-02-29'
+        $valid <= Whether to simulate a valid or invalid crawl
+    */
+    public function seedCampaignFixture($id, $milestone, $valid = true) {
+        // Ensure there's a row in the datagov_campaign table for the specified agency ID
+        $this->hasInDatabase('datagov_campaign',
+            array('office_id' => $id,
+                'milestone' => $milestone,
+                'crawl_status' => 'current',
+                'datajson_status' => $valid ?
+                    $this->getSuccessfulDataJSONStatus() :
+                    $this->getUnsuccessfulDataJSONStatus()));
+    }
 
     public function testOfficeDetailsPageIsValidWithoutCrawls() {
         // We can improve this test by explicitly ensuring that there are no crawls present first,
@@ -131,7 +182,9 @@ class OfficesTest extends DbTestCase
     // Test that OMB-monitored offices are listed in a simple request
     public function testOfficeListIncludesOmbMonitoredOffices() {
 
-        $this->seedCampaignFixture();
+        // All the entries added here get removed automatically during
+        // DbTestCase::tearDown()
+        $this->seedOmbMonitoredOfficeCampaignFixtures();
 
         $output = $this->request('GET', 'offices/qa');
         $this->assertResponseCode(200);

--- a/application/tests/controllers/Strapping_test.php
+++ b/application/tests/controllers/Strapping_test.php
@@ -38,7 +38,6 @@ class StrappingTest extends TestCase
             'Converters > CSV Converter' => ['datagov/csv_to_json'],
             'Converters > Schema Converter' => ['upgrade-schema'],
             'Converters > Data.json merger' => ['merge'],
-            'Rubric' => ['docs/rubric'],
             'Help > Docs' => ['docs'],
             'About' => ['docs/about']
         ];

--- a/application/tests/controllers/Strapping_test.php
+++ b/application/tests/controllers/Strapping_test.php
@@ -32,7 +32,7 @@ class StrappingTest extends TestCase
     public function navLinksProvider() {
         return [
             'Home' => ['offices/qa'],
-            'Agencies' => ['offices'],
+            'Agencies' => ['offices/qa'],
             'Validator' => ['validate'],
             'Converters > ExportAPI' => ['export'],
             'Converters > CSV Converter' => ['datagov/csv_to_json'],

--- a/application/views/header_inc_view.php
+++ b/application/views/header_inc_view.php
@@ -59,8 +59,6 @@
           </ul>
         </li>
 
-        <li><a href="<?php echo site_url('docs/rubric')?>">Rubric</a></li>
-
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Help <b class="caret"></b></a>
           <ul class="dropdown-menu">

--- a/application/views/header_inc_view.php
+++ b/application/views/header_inc_view.php
@@ -46,7 +46,7 @@
       <ul class="nav navbar-nav">
 
 
-        <li><a href="<?php echo site_url('offices')?>">Agencies</a></li>
+        <li><a href="<?php echo site_url('offices/qa')?>">Agencies</a></li>
         <li><a href="<?php echo site_url('validate')?>">Validator</a></li>
 
         <li class="dropdown">

--- a/application/views/office_detail.php
+++ b/application/views/office_detail.php
@@ -43,7 +43,12 @@
         </div>
 
 
-        <div class='agency-trends'>
+        <?php
+            // This section comments out OMB status markup which is unused as of February 2020
+            if(!empty($office_campaign->tracker_status)) {
+        ?>
+
+            <div class='agency-trends'>
             <?php
                 //$edi_public         = !empty($office_campaign->tracker_fields->edi_access_public) ? $office_campaign->tracker_fields->edi_access_public : 0;
             ?>
@@ -73,6 +78,10 @@
 
 
         </div>
+
+        <?php
+            }
+        ?>
 
 
         <h2><?php echo $milestone->milestones[$milestone->selected_milestone];?> - <?php echo date("F jS Y", strtotime($milestone->selected_milestone)) ?></h2>
@@ -166,19 +175,26 @@
                 <p class="form-flash text-warning bg-warning"><strong>Previous Milestone:</strong> The milestone selected is the most recently complete one. The Automated Metrics are a snapshot from the milestone date.</p>
             <?php endif; ?>
 
+            <?php
+                // This section comments out OMB status markup which is unused as of February 2020
+                if(!empty($office_campaign->tracker_status)) {
+            ?>
 
-           <?php if(empty($office_campaign->tracker_status->status) OR $office_campaign->tracker_status->status == 'not-started'): ?>
-                <p class="form-flash text-danger bg-danger"><strong>OMB Review Has Not Begun:</strong> OMB has not begun reviewing the agency for this milestone. The review will begin after the milestone date.</p>
-            <?php endif; ?>
+                <?php if(empty($office_campaign->tracker_status->status) OR $office_campaign->tracker_status->status == 'not-started'): ?>
+                    <p class="form-flash text-danger bg-danger"><strong>OMB Review Has Not Begun:</strong> OMB has not begun reviewing the agency for this milestone. The review will begin after the milestone date.</p>
+                <?php endif; ?>
 
-           <?php if(!empty($office_campaign->tracker_status->status) && $office_campaign->tracker_status->status == 'in-progress'): ?>
-                <p class="form-flash text-warning bg-warning"><strong>OMB Review In Progress:</strong> OMB is currently reviewing the agency for this milestone. This review status indicator will change once the review is complete.</p>
-            <?php endif; ?>
+                <?php if(!empty($office_campaign->tracker_status->status) && $office_campaign->tracker_status->status == 'in-progress'): ?>
+                    <p class="form-flash text-warning bg-warning"><strong>OMB Review In Progress:</strong> OMB is currently reviewing the agency for this milestone. This review status indicator will change once the review is complete.</p>
+                <?php endif; ?>
 
-           <?php if(!empty($office_campaign->tracker_status->status) && $office_campaign->tracker_status->status == 'complete'): ?>
-                <p class="form-flash text-success bg-success"><strong>OMB Review Complete:</strong> OMB has completed the agency review for this milestone. Agencies should contact their OMB desk officer if anything looks incorrect.</p>
-            <?php endif; ?>
+                <?php if(!empty($office_campaign->tracker_status->status) && $office_campaign->tracker_status->status == 'complete'): ?>
+                        <p class="form-flash text-success bg-success"><strong>OMB Review Complete:</strong> OMB has completed the agency review for this milestone. Agencies should contact their OMB desk officer if anything looks incorrect.</p>
+                <?php endif; ?>
 
+           <?php
+                }
+           ?>
 
             <ul class="milestone-selector nav nav-pills">
                 <li class="dropdown active">
@@ -194,586 +210,593 @@
             </ul>
 
 
+            <?php
+                // This section comments out OMB status markup which is unused as of February 2020
+                if(!empty($office_campaign->tracker_status)) {
+            ?>
 
-            <a name="leading_indicators" class="anchor-point"></a>
-            <h3>Leading Indicators <a class="info-icon" href="<?php echo site_url('docs'); ?>#leading_indicators"><span class="glyphicon glyphicon-info-sign"></span></a></h3>
-            <p>These indicators are reviewed by the Office of Management and Budget</p>
-
-
-           <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                <form method="post" action="<?php echo site_url(); ?>datagov/status-review-update" role="form">
-            <?php endif;?>
-
-                <table class="table">
+                <a name="leading_indicators" class="anchor-point"></a>
+                <h3>Leading Indicators <a class="info-icon" href="<?php echo site_url('docs'); ?>#leading_indicators"><span class="glyphicon glyphicon-info-sign"></span></a></h3>
+                <p>These indicators are reviewed by the Office of Management and Budget</p>
 
 
-                        <tr>
-                            <th>Review Status</th>
-                            <td>
-                                <?php
+                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                    <form method="post" action="<?php echo site_url(); ?>datagov/status-review-update" role="form">
+                <?php endif;?>
+
+                    <table class="table">
 
 
-                                    if (!empty($office_campaign->tracker_status->status)) {
-                                        echo  $office_campaign->tracker_status->status;
-                                    }
-                                ?>
-                            </td>
-
-
-                            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                            <tr>
+                                <th>Review Status</th>
                                 <td>
-
-                                    <select name="status">
-                                        <option value="" <?php echo (empty($office_campaign->tracker_status->status)) ? 'selected = "selected"' : '' ?>>Select Status</option>
-                                        <option <?php echo (!empty($office_campaign->tracker_status) && $office_campaign->tracker_status->status == "not-started") ? 'selected = "selected"' : '' ?> value="not-started">Not Reviewed</option>
-                                        <option <?php echo (!empty($office_campaign->tracker_status) && $office_campaign->tracker_status->status == "in-progress") ? 'selected = "selected"' : '' ?> value="in-progress">In Progress</option>
-                                        <option <?php echo (!empty($office_campaign->tracker_status) && $office_campaign->tracker_status->status == "complete") ? 'selected = "selected"' : '' ?> value="complete">Review Complete</option>
-                                    </select>
-
-                                </td>
-                            <?php endif; ?>
-
-                        </tr>
-
-
-                        <tr>
-                            <th>Reviewer</th>
-                            <td>
-                                <?php if (!empty($office_campaign->tracker_status->reviewer_email)) echo  $office_campaign->tracker_status->reviewer_email ?>
-                            </td>
-
-
-                            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                <td>
-                                    <input type="text" name="reviewer_email" value="<?php if (!empty($office_campaign->tracker_status->reviewer_email)) echo  $office_campaign->tracker_status->reviewer_email ?>">
-                                </td>
-                            <?php endif; ?>
-
-                        </tr>
-
-
-
-                        <tr>
-                            <th>Last Updated</th>
-                            <td>
-                                <?php if (!empty( $office_campaign->tracker_status->last_updated)): ?>
-                                    <?php echo  $office_campaign->tracker_status->last_updated ?>
-                                    <?php if (!empty( $office_campaign->tracker_status->last_editor)) echo  ' by ' . $office_campaign->tracker_status->last_editor ?>
-                                <?php endif; ?>
-                            </td>
-
-                            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                <td></td>
-                            <?php endif; ?>
-
-                        </tr>
-
-
-                </table>
-
-            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-
-                    <input type="hidden" name="status_id" value="<?php echo $office_campaign->status_id; ?>">
-                    <input type="hidden" name="office_id" value="<?php echo $office->id; ?>">
-                    <input type="hidden" name="milestone" value="<?php echo $milestone->selected_milestone; ?>">
-
-                    <button type="submit" class="btn btn-success" name="review_status_submit">Update</button>
-
-                </form>
-            <?php endif;?>
-
-
-           <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                <form method="post" action="<?php echo site_url(); ?>datagov/status-update" role="form">
-            <?php endif;?>
-
-            <h3>Assessment Summary</h3>
-                <div class="general-notes">
-
-                    <?php
-                        $status_field_name = 'office_general';
-                        $note_field = "note_office_general";
-                        $note_data = (!empty($notes[$note_field])) ? $notes[$note_field] : '';
-
-                        if(!empty($notes[$note_field])) {
-                            $note_data = $notes[$note_field];
-                        } else {
-                            $note_data = $note_model;
-                        }
-                    ?>
-
-                    <?php if(empty($note_data->current->note)): ?>
-                        <div class="note-heading">
-                            <span class="note-metadata">
-                                No summary has been provided yet
-                            </span>
-                        </div>
-                    <?php endif;?>
-
-                    <?php if(!empty($note_data->current->note) OR ($this->session->userdata('permissions') == $permission_level)): ?>
-                    <div class="edit-toggle">
-                        <div class="edit-area"><?php echo $note_data->current->note_html; ?></div>
-                        <div class="edit-raw hidden" data-fieldname="note_<?php echo $status_field_name ?>"><?php echo $note_data->current->note; ?></div>
-
-                        <?php if (!empty($note_data->current->date) && !empty($note_data->current->author)): ?>
-                            <div class="note-metadata">
-                                Lasted edited on <?php echo $note_data->current->date;?> by <?php echo $note_data->current->author;?>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                            <button class="btn btn-primary edit-button" type="button">Edit</button>
-                        <?php endif; ?>
-                    </div>
-                    <?php endif; ?>
-
-                </div>
-
-
-            <div class="row">
-            <?php
-                $edi_public         = !empty($office_campaign->tracker_fields->edi_access_public) ? $office_campaign->tracker_fields->edi_access_public : 0;
-                $edi_restricted     = !empty($office_campaign->tracker_fields->edi_access_restricted) ? $office_campaign->tracker_fields->edi_access_restricted : 0;
-                $edi_nonpublic      = !empty($office_campaign->tracker_fields->edi_access_nonpublic) ? $office_campaign->tracker_fields->edi_access_nonpublic : 0;
-
-                $edi_total = $edi_public + $edi_restricted + $edi_nonpublic;
-
-                if ($edi_total > 0) :
-            ?>
-
-            <div class="col-sm-4">
-                <h3 style="text-align:center">Inventory Composition</h3>
-                <div id="edi-breakdown" style="height: 250px;"></div>
-            </div>
-
-            <script>
-                new Morris.Donut({
-                  element: 'edi-breakdown',
-                  data: [
-                    {value: <?php echo floor(($edi_public/$edi_total) * 100) ;?>, label: 'Public'},
-                    {value: <?php echo floor(($edi_restricted/$edi_total) * 100) ;?>, label: 'Restricted'},
-                    {value: <?php echo floor(($edi_nonpublic/$edi_total) * 100) ;?>, label: 'Non-Public'},
-                  ],
-                  backgroundColor: '',
-                  labelColor: '#666',
-                  colors: [
-                    '#5cb85c',
-                    '#5bc0de',
-                    '#f0ad4e',
-                    '#95D7BB'
-                  ],
-                  formatter: function (x) { return x + "%"}
-                });
-
-            </script>
-
-            <?php endif; ?>
-
-            <?php
-                $pdl_total          = !empty($office_campaign->tracker_fields->pdl_datasets) ? $office_campaign->tracker_fields->pdl_datasets : 0;
-                $pdl_public         = !empty($office_campaign->tracker_fields->pdl_downloadable) ? $office_campaign->tracker_fields->pdl_downloadable : 0;
-
-                $pdl_unreleased = $pdl_total - $pdl_public;
-
-                if ($pdl_total > 0) :
-            ?>
-
-
-            <div class="col-sm-4">
-                <h3 style="text-align:center">Public Dataset Status</h3>
-                <div id="pdl-breakdown" style="height: 250px;"></div>
-            </div>
-
-            <script>
-                new Morris.Donut({
-                  element: 'pdl-breakdown',
-                  data: [
-                    {value: <?php echo floor(($pdl_public/$pdl_total) * 100) ;?>, label: 'Published'},
-                    {value: <?php echo floor(($pdl_unreleased/$pdl_total) * 100) ;?>, label: 'Unpublished'}
-                  ],
-                  backgroundColor: '',
-                  labelColor: '#666',
-                  colors: [
-                    '#5cb85c',
-                    '#5bc0de',
-                    '#f0ad4e',
-                    '#95D7BB'
-                  ],
-                  formatter: function (x) { return x + "%"}
-                });
-
-            </script>
-
-            <?php endif; ?>
-
-
-            <?php
-                $pdl_link_total          = !empty($office_campaign->tracker_fields->pdl_link_total) ? $office_campaign->tracker_fields->pdl_link_total : 0;
-                $pdl_link_2xx            = !empty($office_campaign->tracker_fields->pdl_link_2xx)   ? $office_campaign->tracker_fields->pdl_link_2xx : 0;
-                $pdl_link_3xx            = !empty($office_campaign->tracker_fields->pdl_link_3xx)   ? $office_campaign->tracker_fields->pdl_link_3xx : 0;
-                $pdl_link_4xx            = !empty($office_campaign->tracker_fields->pdl_link_4xx)   ? $office_campaign->tracker_fields->pdl_link_4xx : 0;
-                $pdl_link_5xx            = !empty($office_campaign->tracker_fields->pdl_link_5xx)   ? $office_campaign->tracker_fields->pdl_link_5xx : 0;
-
-                $pdl_link_other         = $pdl_link_total - ($pdl_link_2xx + $pdl_link_3xx + $pdl_link_4xx + $pdl_link_5xx);
-
-                if ($pdl_link_total > 0 && $pdl_link_2xx > 0) :
-            ?>
-
-
-            <div class="col-sm-4">
-                <h3 style="text-align:center">Dataset Link Quality</h3>
-                <div id="link-status" style="height: 250px;"></div>
-            </div>
-
-            <script>
-                new Morris.Donut({
-                  element: 'link-status',
-                  data: [
-                    {value: <?php echo round(($pdl_link_2xx/$pdl_link_total) * 100, 1) ;?>, label: 'Working'},
-                    {value: <?php echo round(($pdl_link_3xx/$pdl_link_total) * 100, 1) ;?>, label: 'Redirected'},
-                    {value: <?php echo round(($pdl_link_4xx/$pdl_link_total) * 100, 1) ;?>, label: 'Broken'},
-                    {value: <?php echo round(($pdl_link_5xx/$pdl_link_total) * 100, 1) ;?>, label: 'Errors'},
-                    {value: <?php echo round(($pdl_link_other/$pdl_link_total) * 100, 1) ;?>, label: 'Other'}
-                  ],
-                  backgroundColor: '',
-                  labelColor: '#666',
-                  colors: [
-                    '#5cb85c',
-                    '#5bc0de',
-                    '#a94442',
-                    '#f0ad4e',
-                    '#ccc'
-                  ],
-                  formatter: function (x) { return x + "%"}
-                });
-
-            </script>
-
-            <?php endif; ?>
-
-
-
-            </div>
-
-
-            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                <div  class="pull-right" style="margin : 1em 0;">
-                    <button class="btn btn-default btn-xs" id="accShow">Show All Notes</button>
-                    <button type="submit" class="btn btn-success btn-xs">Update</button>
-                </div>
-            <?php endif;?>
-
-
-            <!-- Nav tabs -->
-            <ul class="nav nav-tabs tracker-sections">
-
-                <?php foreach ($section_breakdown as $section_abbreviation => $section_title): ?>
-
-                    <?php
-                        if ($milestone->selected_milestone < '2014-11-30' && $section_abbreviation == 'ui') continue;
-
-                        $aggregate_score = $section_abbreviation . '_aggregate_score';
-
-                        if(!empty($office_campaign->tracker_fields->$aggregate_score)) {
-                            $section_score =  'bg-' . status_color($office_campaign->tracker_fields->$aggregate_score);
-                        } else {
-                            $section_score =  '';
-                        }
-                    ?>
-
-                    <li  <?php if($section_abbreviation == $active_section) echo 'class="active"'; ?>>
-                        <a name="<?php echo $section_abbreviation . '_tab';?>" href="#<?php echo $section_abbreviation;?>" data-toggle="tab">
-                            <?php echo $section_title;?>
-                            <div class="section-score <?php echo $section_score?>"></div>
-                        </a>
-                    </li>
-                <?php endforeach; reset($section_breakdown);  ?>
-            </ul>
-
-                <!-- Tab panes -->
-                <div class="tab-content tracker-content">
-
-                  <?php foreach ($section_breakdown as $section_abbreviation => $section_title): ?>
-                        <div class="tab-pane <?php if($section_abbreviation == $active_section) echo 'active'; ?>" id="<?php echo $section_abbreviation;?>">
-
-
-
-                            <div class="section-notes">
-
-                                <?php
-                                    $note_field = 'note_' . $section_abbreviation . '_aggregate_score';
-                                    $note_data = (!empty($notes[$note_field])) ? $notes[$note_field] : $note_model;
-                                ?>
-
-                                <div><?php echo $note_data->current->note_html; ?></div>
-
-                                <?php if (!empty($note_data->current->date) && !empty($note_data->current->author)): ?>
-                                    <div class="note-metadata">
-                                        Lasted edited on <?php echo $note_data->current->date;?> by <?php echo $note_data->current->author;?>
-                                    </div>
-                                <?php endif; ?>
-
-                            </div>
-
-                            <?php
-                                $highlight_field = $section_abbreviation . '_selected_best_practice';
-                            ?>
-
-                           <?php if(!empty($office_campaign->tracker_fields->$highlight_field) && $office_campaign->tracker_fields->$highlight_field == 'yes'): ?>
-                                <p class="form-flash text-success bg-success"><strong>Best Practice:</strong> <?php echo $office->name ?> has been highlighted for demonstrating a best practice on the <?php echo $section_title ?> indicator</p>
-                            <?php endif; ?>
-
-
-                           <table class="table table-striped table-hover" id="note-expander-parent">
-
-                                <th class="table-header">
-                                    <th>Status</th>
-
-                                    <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                        <th></th>
-                                    <?php endif; ?>
-
-                                    <th>Indicator</th>
-                                    <th>Automated Metrics</th>
-
-                                    <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                        <th></th>
-                                    <?php endif; ?>
-
-                                </th>
-
-
-                                <?php foreach ($tracker_model as $tracker_field_name => $tracker_field_meta) : ?>
-
                                     <?php
 
-                                        // Skip this field if it's not part of current section
-                                        if (substr($tracker_field_name, 0, strlen($section_abbreviation)) !== $section_abbreviation) continue;
 
-                                        // Skip this field if it's not used for this milestone
-                                        if (!empty($tracker_field_meta->milestones_start) &&
-                                            !empty($tracker_field_meta->milestones_end) ) {
-
-                                            $milestone_start = strtotime($tracker_field_meta->milestones_start);
-                                            $milestone_end = strtotime($tracker_field_meta->milestones_end);
-                                            $milestone_selected = strtotime($milestone->selected_milestone);
-
-                                            if(($milestone_selected > $milestone_end) OR ($milestone_selected < $milestone_start)) {
-                                                continue;
-                                            }
-
+                                        if (!empty($office_campaign->tracker_status->status)) {
+                                            echo  $office_campaign->tracker_status->status;
                                         }
-
-                                        // If this is a best practice highlight field, don't show it unless logged in
-                                        if(strpos($tracker_field_name, 'selected_best_practice') !== false && !$this->session->userdata('permissions') == $permission_level) continue;
-
-                                        if (!empty($office_campaign->tracker_fields->$tracker_field_name)) {
-                                            if($office_campaign->tracker_fields->$tracker_field_name == 'yes' || $office_campaign->tracker_fields->$tracker_field_name == 'green') {
-                                                $status_icon = '<i class="text-success fa fa-check-square"></i>';
-                                                $status_class = 'success';
-                                            } else if ($office_campaign->tracker_fields->$tracker_field_name == 'no' || $office_campaign->tracker_fields->$tracker_field_name == 'red') {
-                                                $status_icon =  '<i class="text-danger fa fa-times-circle"></i>';
-                                                $status_class = 'danger';
-                                            } else {
-                                                $status_icon = '<i class="text-warning fa fa-exclamation-triangle"></i>';
-                                                $status_class = '';
-                                            }
-                                        } else {
-                                            //$office_campaign->tracker_fields->$tracker_field_name = '';
-                                            $status_icon = '';
-                                            $status_class = '';
-                                        }
-
                                     ?>
-
-                                    <tr <?php //if(!empty($status_class)) echo "class=\"$status_class\""; ?>>
-                                        <td class="col-md-1">
-                                            <?php
-                                                $overflow_text = false;
-
-                                                if (!empty($status_icon) && ($tracker_field_meta->type == "select" || $tracker_field_meta->type == "traffic")) {
-                                                    echo $status_icon;
-                                                } else {
-                                                    if (!empty($office_campaign->tracker_fields->$tracker_field_name)) {
-                                                        if(strlen($office_campaign->tracker_fields->$tracker_field_name) < 20) {
-                                                            if ($tracker_field_meta->type == "choices" && !empty($tracker_field_meta->choices)) {
-                                                                foreach ($tracker_field_meta->choices as $option_name => $option_label) {
-                                                                    if ($office_campaign->tracker_fields->$tracker_field_name == $option_name) {
-                                                                        echo $option_label;
-                                                                        break;
-                                                                    }
-                                                                }
-                                                            } else {
-                                                                echo $office_campaign->tracker_fields->$tracker_field_name;
-                                                            }
-                                                        } else {
-                                                            $overflow_text = true;
-                                                            echo '<em>See below</em>';
-                                                        }
-                                                    }
-                                                }
-                                            ?>
-                                        </td>
-
-                                        <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                            <td class="col-md-2">
-
-                                                <?php if ($tracker_field_meta->type == "select") : ?>
-                                                    <select name="<?php echo $tracker_field_name ?>">
-                                                        <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Status</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "yes") ? 'selected = "selected"' : '' ?> value="yes">Yes</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "no") ? 'selected = "selected"' : '' ?> value="no">No</option>
-                                                    </select>
-                                                <?php endif; ?>
-
-                                                <?php if ($tracker_field_meta->type == "grade") : ?>
-                                                    <select name="<?php echo $tracker_field_name ?>">
-                                                        <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Grade</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "A") ? 'selected = "selected"' : '' ?> value="A">A</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "B") ? 'selected = "selected"' : '' ?> value="B">B</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "C") ? 'selected = "selected"' : '' ?> value="C">C</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "D") ? 'selected = "selected"' : '' ?> value="D">D</option>
-                                                    </select>
-                                                <?php endif; ?>
+                                </td>
 
 
-                                                <?php if ($tracker_field_meta->type == "progress") : ?>
-                                                    <select name="<?php echo $tracker_field_name ?>">
-                                                        <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Progress</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "progress") ? 'selected = "selected"' : '' ?> value="progress">Progress</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "neutral") ? 'selected = "selected"' : '' ?> value="neutral">Neutral</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "retrogress") ? 'selected = "selected"' : '' ?> value="retrogress">Retrogress</option>
-                                                    </select>
-                                                <?php endif; ?>
+                                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                    <td>
+
+                                        <select name="status">
+                                            <option value="" <?php echo (empty($office_campaign->tracker_status->status)) ? 'selected = "selected"' : '' ?>>Select Status</option>
+                                            <option <?php echo (!empty($office_campaign->tracker_status) && $office_campaign->tracker_status->status == "not-started") ? 'selected = "selected"' : '' ?> value="not-started">Not Reviewed</option>
+                                            <option <?php echo (!empty($office_campaign->tracker_status) && $office_campaign->tracker_status->status == "in-progress") ? 'selected = "selected"' : '' ?> value="in-progress">In Progress</option>
+                                            <option <?php echo (!empty($office_campaign->tracker_status) && $office_campaign->tracker_status->status == "complete") ? 'selected = "selected"' : '' ?> value="complete">Review Complete</option>
+                                        </select>
+
+                                    </td>
+                                <?php endif; ?>
+
+                            </tr>
 
 
-                                                <?php if ($tracker_field_meta->type == "traffic") : ?>
-                                                    <select name="<?php echo $tracker_field_name ?>">
-                                                        <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Status</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "red") ? 'selected = "selected"' : '' ?> value="red">Red</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "yellow") ? 'selected = "selected"' : '' ?> value="yellow">Yellow</option>
-                                                        <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "green") ? 'selected = "selected"' : '' ?> value="green">Green</option>
-                                                    </select>
-                                                <?php endif; ?>
-
-                                                <?php if ($tracker_field_meta->type == "choices" && !empty($tracker_field_meta->choices)) : ?>
-                                                    <select name="<?php echo $tracker_field_name ?>">
-                                                        <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Status</option>
-                                                        <?php foreach ($tracker_field_meta->choices as $option_name => $option_label): ?>
-                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == $option_name) ? 'selected = "selected"' : '' ?> value="<?php echo $option_name; ?>"><?php echo $option_label; ?></option>
-                                                        <?php endforeach; ?>
-                                                    </select>
-                                                <?php endif; ?>
+                            <tr>
+                                <th>Reviewer</th>
+                                <td>
+                                    <?php if (!empty($office_campaign->tracker_status->reviewer_email)) echo  $office_campaign->tracker_status->reviewer_email ?>
+                                </td>
 
 
-                                                <?php if ($tracker_field_meta->type == "string") : ?>
-                                                    <input type="text" id="input-<?php echo $tracker_field_name ?>" name="<?php echo $tracker_field_name ?>" value="<?php echo $office_campaign->tracker_fields->$tracker_field_name;?>">
-                                                <?php endif; ?>
-                                            </td>
-                                        <?php endif; ?>
+                                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                    <td>
+                                        <input type="text" name="reviewer_email" value="<?php if (!empty($office_campaign->tracker_status->reviewer_email)) echo  $office_campaign->tracker_status->reviewer_email ?>">
+                                    </td>
+                                <?php endif; ?>
 
-                                        <td class="tracker-field">
-                                            <a name="tracker_<?php echo $tracker_field_name ?>" class="anchor-point"></a>
-                                            <strong>
-                                                <a href="<?php echo site_url('docs') . '#' . $tracker_field_name ?>">
-                                                    <span class="glyphicon glyphicon-info-sign"></span>
-                                                </a>
-                                                    <?php echo $tracker_field_meta->label ?>
-                                            </strong>
-                                        </td>
-                                        <td>
-
-                                            <?php if (array_search($tracker_field_name, $crawl_details) !== false):?>
-
-                                                <a href="#<?php echo $tracker_field_name ?>">Crawl details</a>
-
-                                                <?php if ($this->session->userdata('permissions') == $permission_level && $tracker_field_meta->type == 'string') : ?>
-                                                    <button type="button" id="autofill-<?php echo $tracker_field_name ?>" class="autofill-button" data-value="<?php echo $tracker_field_name ?>">Autofill</button>
-                                                <?php endif; ?>
-
-                                            <?php endif; ?>
-
-                                        </td>
-
-                                        <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                        <td>
-                                            <a class="btn btn-xs btn-default collapsed pull-right" href="#note-expander-<?php echo $tracker_field_name ?>" data-parent="note-expander-parent" data-toggle="collapse">
-                                                Notes
-                                            </a>
-                                        </td>
-                                        <?php endif; ?>
-                                    </tr>
-
-
-                                    <?php if ($overflow_text) : ?>
-                                    <tr>
-                                        <td colspan="5" class="overflow-row">
-                                            <?php echo $office_campaign->tracker_fields->$tracker_field_name; ?>
-                                        </td>
-                                    </tr>
-                                    <?php endif;?>
-
-                                    <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                    <tr>
-                                        <td colspan="5" class="hidden-row">
-                                            <div class="edit-toggle collapse container form-group" id="note-expander-<?php echo $tracker_field_name ?>">
-
-                                                <?php
-                                                    $note_field = "note_$tracker_field_name";
-
-                                                    $note_data = (!empty($notes[$note_field])) ? $notes[$note_field] : '';
-
-                                                    if(!empty($notes[$note_field])) {
-                                                        $note_data = $notes[$note_field];
-                                                    } else {
-                                                        $note_data = $note_model;
-                                                    }
-                                                ?>
-
-                                                <div class="edit-area"><?php echo $note_data->current->note_html; ?></div>
-                                                <div class="edit-raw hidden" data-fieldname="note_<?php echo $tracker_field_name ?>"><?php echo $note_data->current->note; ?></div>
-
-                                                <?php if (!empty($note_data->current->date) && !empty($note_data->current->author)): ?>
-                                                    <div class="note-metadata">
-                                                        Lasted edited on <?php echo $note_data->current->date;?> by <?php echo $note_data->current->author;?>
-                                                    </div>
-                                                <?php endif; ?>
-
-                                                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
-                                                    <button class="btn btn-primary edit-button pull-right" type="button">Edit</button>
-                                                <?php endif; ?>
-
-
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <?php endif;?>
-
-                                <?php reset($tracker_model); endforeach; ?>
-
-                            </table>
+                            </tr>
 
 
 
+                            <tr>
+                                <th>Last Updated</th>
+                                <td>
+                                    <?php if (!empty( $office_campaign->tracker_status->last_updated)): ?>
+                                        <?php echo  $office_campaign->tracker_status->last_updated ?>
+                                        <?php if (!empty( $office_campaign->tracker_status->last_editor)) echo  ' by ' . $office_campaign->tracker_status->last_editor ?>
+                                    <?php endif; ?>
+                                </td>
+
+                                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                    <td></td>
+                                <?php endif; ?>
+
+                            </tr>
+
+
+                    </table>
+
+                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+
+                        <input type="hidden" name="status_id" value="<?php echo $office_campaign->status_id; ?>">
+                        <input type="hidden" name="office_id" value="<?php echo $office->id; ?>">
+                        <input type="hidden" name="milestone" value="<?php echo $milestone->selected_milestone; ?>">
+
+                        <button type="submit" class="btn btn-success" name="review_status_submit">Update</button>
+
+                    </form>
+                <?php endif;?>
+
+
+                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                    <form method="post" action="<?php echo site_url(); ?>datagov/status-update" role="form">
+                <?php endif;?>
+
+                <h3>Assessment Summary</h3>
+                    <div class="general-notes">
+
+                        <?php
+                            $status_field_name = 'office_general';
+                            $note_field = "note_office_general";
+                            $note_data = (!empty($notes[$note_field])) ? $notes[$note_field] : '';
+
+                            if(!empty($notes[$note_field])) {
+                                $note_data = $notes[$note_field];
+                            } else {
+                                $note_data = $note_model;
+                            }
+                        ?>
+
+                        <?php if(empty($note_data->current->note)): ?>
+                            <div class="note-heading">
+                                <span class="note-metadata">
+                                    No summary has been provided yet
+                                </span>
+                            </div>
+                        <?php endif;?>
+
+                        <?php if(!empty($note_data->current->note) OR ($this->session->userdata('permissions') == $permission_level)): ?>
+                        <div class="edit-toggle">
+                            <div class="edit-area"><?php echo $note_data->current->note_html; ?></div>
+                            <div class="edit-raw hidden" data-fieldname="note_<?php echo $status_field_name ?>"><?php echo $note_data->current->note; ?></div>
+
+                            <?php if (!empty($note_data->current->date) && !empty($note_data->current->author)): ?>
+                                <div class="note-metadata">
+                                    Lasted edited on <?php echo $note_data->current->date;?> by <?php echo $note_data->current->author;?>
+                                </div>
+                            <?php endif; ?>
+
+                            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                <button class="btn btn-primary edit-button" type="button">Edit</button>
+                            <?php endif; ?>
                         </div>
-                    <?php endforeach; ?>
+                        <?php endif; ?>
+
+                    </div>
+
+
+                <div class="row">
+                <?php
+                    $edi_public         = !empty($office_campaign->tracker_fields->edi_access_public) ? $office_campaign->tracker_fields->edi_access_public : 0;
+                    $edi_restricted     = !empty($office_campaign->tracker_fields->edi_access_restricted) ? $office_campaign->tracker_fields->edi_access_restricted : 0;
+                    $edi_nonpublic      = !empty($office_campaign->tracker_fields->edi_access_nonpublic) ? $office_campaign->tracker_fields->edi_access_nonpublic : 0;
+
+                    $edi_total = $edi_public + $edi_restricted + $edi_nonpublic;
+
+                    if ($edi_total > 0) :
+                ?>
+
+                <div class="col-sm-4">
+                    <h3 style="text-align:center">Inventory Composition</h3>
+                    <div id="edi-breakdown" style="height: 250px;"></div>
+                </div>
+
+                <script>
+                    new Morris.Donut({
+                    element: 'edi-breakdown',
+                    data: [
+                        {value: <?php echo floor(($edi_public/$edi_total) * 100) ;?>, label: 'Public'},
+                        {value: <?php echo floor(($edi_restricted/$edi_total) * 100) ;?>, label: 'Restricted'},
+                        {value: <?php echo floor(($edi_nonpublic/$edi_total) * 100) ;?>, label: 'Non-Public'},
+                    ],
+                    backgroundColor: '',
+                    labelColor: '#666',
+                    colors: [
+                        '#5cb85c',
+                        '#5bc0de',
+                        '#f0ad4e',
+                        '#95D7BB'
+                    ],
+                    formatter: function (x) { return x + "%"}
+                    });
+
+                </script>
+
+                <?php endif; ?>
+
+                <?php
+                    $pdl_total          = !empty($office_campaign->tracker_fields->pdl_datasets) ? $office_campaign->tracker_fields->pdl_datasets : 0;
+                    $pdl_public         = !empty($office_campaign->tracker_fields->pdl_downloadable) ? $office_campaign->tracker_fields->pdl_downloadable : 0;
+
+                    $pdl_unreleased = $pdl_total - $pdl_public;
+
+                    if ($pdl_total > 0) :
+                ?>
+
+
+                <div class="col-sm-4">
+                    <h3 style="text-align:center">Public Dataset Status</h3>
+                    <div id="pdl-breakdown" style="height: 250px;"></div>
+                </div>
+
+                <script>
+                    new Morris.Donut({
+                    element: 'pdl-breakdown',
+                    data: [
+                        {value: <?php echo floor(($pdl_public/$pdl_total) * 100) ;?>, label: 'Published'},
+                        {value: <?php echo floor(($pdl_unreleased/$pdl_total) * 100) ;?>, label: 'Unpublished'}
+                    ],
+                    backgroundColor: '',
+                    labelColor: '#666',
+                    colors: [
+                        '#5cb85c',
+                        '#5bc0de',
+                        '#f0ad4e',
+                        '#95D7BB'
+                    ],
+                    formatter: function (x) { return x + "%"}
+                    });
+
+                </script>
+
+                <?php endif; ?>
+
+
+                <?php
+                    $pdl_link_total          = !empty($office_campaign->tracker_fields->pdl_link_total) ? $office_campaign->tracker_fields->pdl_link_total : 0;
+                    $pdl_link_2xx            = !empty($office_campaign->tracker_fields->pdl_link_2xx)   ? $office_campaign->tracker_fields->pdl_link_2xx : 0;
+                    $pdl_link_3xx            = !empty($office_campaign->tracker_fields->pdl_link_3xx)   ? $office_campaign->tracker_fields->pdl_link_3xx : 0;
+                    $pdl_link_4xx            = !empty($office_campaign->tracker_fields->pdl_link_4xx)   ? $office_campaign->tracker_fields->pdl_link_4xx : 0;
+                    $pdl_link_5xx            = !empty($office_campaign->tracker_fields->pdl_link_5xx)   ? $office_campaign->tracker_fields->pdl_link_5xx : 0;
+
+                    $pdl_link_other         = $pdl_link_total - ($pdl_link_2xx + $pdl_link_3xx + $pdl_link_4xx + $pdl_link_5xx);
+
+                    if ($pdl_link_total > 0 && $pdl_link_2xx > 0) :
+                ?>
+
+
+                <div class="col-sm-4">
+                    <h3 style="text-align:center">Dataset Link Quality</h3>
+                    <div id="link-status" style="height: 250px;"></div>
+                </div>
+
+                <script>
+                    new Morris.Donut({
+                    element: 'link-status',
+                    data: [
+                        {value: <?php echo round(($pdl_link_2xx/$pdl_link_total) * 100, 1) ;?>, label: 'Working'},
+                        {value: <?php echo round(($pdl_link_3xx/$pdl_link_total) * 100, 1) ;?>, label: 'Redirected'},
+                        {value: <?php echo round(($pdl_link_4xx/$pdl_link_total) * 100, 1) ;?>, label: 'Broken'},
+                        {value: <?php echo round(($pdl_link_5xx/$pdl_link_total) * 100, 1) ;?>, label: 'Errors'},
+                        {value: <?php echo round(($pdl_link_other/$pdl_link_total) * 100, 1) ;?>, label: 'Other'}
+                    ],
+                    backgroundColor: '',
+                    labelColor: '#666',
+                    colors: [
+                        '#5cb85c',
+                        '#5bc0de',
+                        '#a94442',
+                        '#f0ad4e',
+                        '#ccc'
+                    ],
+                    formatter: function (x) { return x + "%"}
+                    });
+
+                </script>
+
+                <?php endif; ?>
+
+
+
                 </div>
 
 
-            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                    <div  class="pull-right" style="margin : 1em 0;">
+                        <button class="btn btn-default btn-xs" id="accShow">Show All Notes</button>
+                        <button type="submit" class="btn btn-success btn-xs">Update</button>
+                    </div>
+                <?php endif;?>
 
 
-                    <?php if(!empty($office_campaign->tracker_status)): ?>
-                        <input type="hidden" name="reviewer_email" value="<?php if (!empty($office_campaign->tracker_status->reviewer_email)) echo  $office_campaign->tracker_status->reviewer_email ?>">
-                        <input type="hidden" name="status" value="<?php if (!empty($office_campaign->tracker_status->status)) echo  $office_campaign->tracker_status->status ?>">
-                    <?php endif; ?>
+                <!-- Nav tabs -->
+                <ul class="nav nav-tabs tracker-sections">
 
-                    <input type="hidden" name="office_id" value="<?php echo $office->id; ?>">
-                    <input type="hidden" name="status_id" value="<?php echo $office_campaign->status_id; ?>">
-                    <input type="hidden" name="milestone" value="<?php echo $milestone->selected_milestone; ?>">
-                </form>
-            <?php endif; ?>
+                    <?php foreach ($section_breakdown as $section_abbreviation => $section_title): ?>
 
+                        <?php
+                            if ($milestone->selected_milestone < '2014-11-30' && $section_abbreviation == 'ui') continue;
+
+                            $aggregate_score = $section_abbreviation . '_aggregate_score';
+
+                            if(!empty($office_campaign->tracker_fields->$aggregate_score)) {
+                                $section_score =  'bg-' . status_color($office_campaign->tracker_fields->$aggregate_score);
+                            } else {
+                                $section_score =  '';
+                            }
+                        ?>
+
+                        <li  <?php if($section_abbreviation == $active_section) echo 'class="active"'; ?>>
+                            <a name="<?php echo $section_abbreviation . '_tab';?>" href="#<?php echo $section_abbreviation;?>" data-toggle="tab">
+                                <?php echo $section_title;?>
+                                <div class="section-score <?php echo $section_score?>"></div>
+                            </a>
+                        </li>
+                    <?php endforeach; reset($section_breakdown);  ?>
+                </ul>
+
+                    <!-- Tab panes -->
+                    <div class="tab-content tracker-content">
+
+                    <?php foreach ($section_breakdown as $section_abbreviation => $section_title): ?>
+                            <div class="tab-pane <?php if($section_abbreviation == $active_section) echo 'active'; ?>" id="<?php echo $section_abbreviation;?>">
+
+
+
+                                <div class="section-notes">
+
+                                    <?php
+                                        $note_field = 'note_' . $section_abbreviation . '_aggregate_score';
+                                        $note_data = (!empty($notes[$note_field])) ? $notes[$note_field] : $note_model;
+                                    ?>
+
+                                    <div><?php echo $note_data->current->note_html; ?></div>
+
+                                    <?php if (!empty($note_data->current->date) && !empty($note_data->current->author)): ?>
+                                        <div class="note-metadata">
+                                            Lasted edited on <?php echo $note_data->current->date;?> by <?php echo $note_data->current->author;?>
+                                        </div>
+                                    <?php endif; ?>
+
+                                </div>
+
+                                <?php
+                                    $highlight_field = $section_abbreviation . '_selected_best_practice';
+                                ?>
+
+                            <?php if(!empty($office_campaign->tracker_fields->$highlight_field) && $office_campaign->tracker_fields->$highlight_field == 'yes'): ?>
+                                    <p class="form-flash text-success bg-success"><strong>Best Practice:</strong> <?php echo $office->name ?> has been highlighted for demonstrating a best practice on the <?php echo $section_title ?> indicator</p>
+                                <?php endif; ?>
+
+
+                            <table class="table table-striped table-hover" id="note-expander-parent">
+
+                                    <th class="table-header">
+                                        <th>Status</th>
+
+                                        <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                            <th></th>
+                                        <?php endif; ?>
+
+                                        <th>Indicator</th>
+                                        <th>Automated Metrics</th>
+
+                                        <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                            <th></th>
+                                        <?php endif; ?>
+
+                                    </th>
+
+
+                                    <?php foreach ($tracker_model as $tracker_field_name => $tracker_field_meta) : ?>
+
+                                        <?php
+
+                                            // Skip this field if it's not part of current section
+                                            if (substr($tracker_field_name, 0, strlen($section_abbreviation)) !== $section_abbreviation) continue;
+
+                                            // Skip this field if it's not used for this milestone
+                                            if (!empty($tracker_field_meta->milestones_start) &&
+                                                !empty($tracker_field_meta->milestones_end) ) {
+
+                                                $milestone_start = strtotime($tracker_field_meta->milestones_start);
+                                                $milestone_end = strtotime($tracker_field_meta->milestones_end);
+                                                $milestone_selected = strtotime($milestone->selected_milestone);
+
+                                                if(($milestone_selected > $milestone_end) OR ($milestone_selected < $milestone_start)) {
+                                                    continue;
+                                                }
+
+                                            }
+
+                                            // If this is a best practice highlight field, don't show it unless logged in
+                                            if(strpos($tracker_field_name, 'selected_best_practice') !== false && !$this->session->userdata('permissions') == $permission_level) continue;
+
+                                            if (!empty($office_campaign->tracker_fields->$tracker_field_name)) {
+                                                if($office_campaign->tracker_fields->$tracker_field_name == 'yes' || $office_campaign->tracker_fields->$tracker_field_name == 'green') {
+                                                    $status_icon = '<i class="text-success fa fa-check-square"></i>';
+                                                    $status_class = 'success';
+                                                } else if ($office_campaign->tracker_fields->$tracker_field_name == 'no' || $office_campaign->tracker_fields->$tracker_field_name == 'red') {
+                                                    $status_icon =  '<i class="text-danger fa fa-times-circle"></i>';
+                                                    $status_class = 'danger';
+                                                } else {
+                                                    $status_icon = '<i class="text-warning fa fa-exclamation-triangle"></i>';
+                                                    $status_class = '';
+                                                }
+                                            } else {
+                                                //$office_campaign->tracker_fields->$tracker_field_name = '';
+                                                $status_icon = '';
+                                                $status_class = '';
+                                            }
+
+                                        ?>
+
+                                        <tr <?php //if(!empty($status_class)) echo "class=\"$status_class\""; ?>>
+                                            <td class="col-md-1">
+                                                <?php
+                                                    $overflow_text = false;
+
+                                                    if (!empty($status_icon) && ($tracker_field_meta->type == "select" || $tracker_field_meta->type == "traffic")) {
+                                                        echo $status_icon;
+                                                    } else {
+                                                        if (!empty($office_campaign->tracker_fields->$tracker_field_name)) {
+                                                            if(strlen($office_campaign->tracker_fields->$tracker_field_name) < 20) {
+                                                                if ($tracker_field_meta->type == "choices" && !empty($tracker_field_meta->choices)) {
+                                                                    foreach ($tracker_field_meta->choices as $option_name => $option_label) {
+                                                                        if ($office_campaign->tracker_fields->$tracker_field_name == $option_name) {
+                                                                            echo $option_label;
+                                                                            break;
+                                                                        }
+                                                                    }
+                                                                } else {
+                                                                    echo $office_campaign->tracker_fields->$tracker_field_name;
+                                                                }
+                                                            } else {
+                                                                $overflow_text = true;
+                                                                echo '<em>See below</em>';
+                                                            }
+                                                        }
+                                                    }
+                                                ?>
+                                            </td>
+
+                                            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                                <td class="col-md-2">
+
+                                                    <?php if ($tracker_field_meta->type == "select") : ?>
+                                                        <select name="<?php echo $tracker_field_name ?>">
+                                                            <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Status</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "yes") ? 'selected = "selected"' : '' ?> value="yes">Yes</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "no") ? 'selected = "selected"' : '' ?> value="no">No</option>
+                                                        </select>
+                                                    <?php endif; ?>
+
+                                                    <?php if ($tracker_field_meta->type == "grade") : ?>
+                                                        <select name="<?php echo $tracker_field_name ?>">
+                                                            <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Grade</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "A") ? 'selected = "selected"' : '' ?> value="A">A</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "B") ? 'selected = "selected"' : '' ?> value="B">B</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "C") ? 'selected = "selected"' : '' ?> value="C">C</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "D") ? 'selected = "selected"' : '' ?> value="D">D</option>
+                                                        </select>
+                                                    <?php endif; ?>
+
+
+                                                    <?php if ($tracker_field_meta->type == "progress") : ?>
+                                                        <select name="<?php echo $tracker_field_name ?>">
+                                                            <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Progress</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "progress") ? 'selected = "selected"' : '' ?> value="progress">Progress</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "neutral") ? 'selected = "selected"' : '' ?> value="neutral">Neutral</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "retrogress") ? 'selected = "selected"' : '' ?> value="retrogress">Retrogress</option>
+                                                        </select>
+                                                    <?php endif; ?>
+
+
+                                                    <?php if ($tracker_field_meta->type == "traffic") : ?>
+                                                        <select name="<?php echo $tracker_field_name ?>">
+                                                            <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Status</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "red") ? 'selected = "selected"' : '' ?> value="red">Red</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "yellow") ? 'selected = "selected"' : '' ?> value="yellow">Yellow</option>
+                                                            <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == "green") ? 'selected = "selected"' : '' ?> value="green">Green</option>
+                                                        </select>
+                                                    <?php endif; ?>
+
+                                                    <?php if ($tracker_field_meta->type == "choices" && !empty($tracker_field_meta->choices)) : ?>
+                                                        <select name="<?php echo $tracker_field_name ?>">
+                                                            <option value="" <?php echo (empty($office_campaign->tracker_fields->$tracker_field_name)) ? 'selected = "selected"' : '' ?>>Select Status</option>
+                                                            <?php foreach ($tracker_field_meta->choices as $option_name => $option_label): ?>
+                                                                <option <?php echo ($office_campaign->tracker_fields->$tracker_field_name == $option_name) ? 'selected = "selected"' : '' ?> value="<?php echo $option_name; ?>"><?php echo $option_label; ?></option>
+                                                            <?php endforeach; ?>
+                                                        </select>
+                                                    <?php endif; ?>
+
+
+                                                    <?php if ($tracker_field_meta->type == "string") : ?>
+                                                        <input type="text" id="input-<?php echo $tracker_field_name ?>" name="<?php echo $tracker_field_name ?>" value="<?php echo $office_campaign->tracker_fields->$tracker_field_name;?>">
+                                                    <?php endif; ?>
+                                                </td>
+                                            <?php endif; ?>
+
+                                            <td class="tracker-field">
+                                                <a name="tracker_<?php echo $tracker_field_name ?>" class="anchor-point"></a>
+                                                <strong>
+                                                    <a href="<?php echo site_url('docs') . '#' . $tracker_field_name ?>">
+                                                        <span class="glyphicon glyphicon-info-sign"></span>
+                                                    </a>
+                                                        <?php echo $tracker_field_meta->label ?>
+                                                </strong>
+                                            </td>
+                                            <td>
+
+                                                <?php if (array_search($tracker_field_name, $crawl_details) !== false):?>
+
+                                                    <a href="#<?php echo $tracker_field_name ?>">Crawl details</a>
+
+                                                    <?php if ($this->session->userdata('permissions') == $permission_level && $tracker_field_meta->type == 'string') : ?>
+                                                        <button type="button" id="autofill-<?php echo $tracker_field_name ?>" class="autofill-button" data-value="<?php echo $tracker_field_name ?>">Autofill</button>
+                                                    <?php endif; ?>
+
+                                                <?php endif; ?>
+
+                                            </td>
+
+                                            <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                            <td>
+                                                <a class="btn btn-xs btn-default collapsed pull-right" href="#note-expander-<?php echo $tracker_field_name ?>" data-parent="note-expander-parent" data-toggle="collapse">
+                                                    Notes
+                                                </a>
+                                            </td>
+                                            <?php endif; ?>
+                                        </tr>
+
+
+                                        <?php if ($overflow_text) : ?>
+                                        <tr>
+                                            <td colspan="5" class="overflow-row">
+                                                <?php echo $office_campaign->tracker_fields->$tracker_field_name; ?>
+                                            </td>
+                                        </tr>
+                                        <?php endif;?>
+
+                                        <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                        <tr>
+                                            <td colspan="5" class="hidden-row">
+                                                <div class="edit-toggle collapse container form-group" id="note-expander-<?php echo $tracker_field_name ?>">
+
+                                                    <?php
+                                                        $note_field = "note_$tracker_field_name";
+
+                                                        $note_data = (!empty($notes[$note_field])) ? $notes[$note_field] : '';
+
+                                                        if(!empty($notes[$note_field])) {
+                                                            $note_data = $notes[$note_field];
+                                                        } else {
+                                                            $note_data = $note_model;
+                                                        }
+                                                    ?>
+
+                                                    <div class="edit-area"><?php echo $note_data->current->note_html; ?></div>
+                                                    <div class="edit-raw hidden" data-fieldname="note_<?php echo $tracker_field_name ?>"><?php echo $note_data->current->note; ?></div>
+
+                                                    <?php if (!empty($note_data->current->date) && !empty($note_data->current->author)): ?>
+                                                        <div class="note-metadata">
+                                                            Lasted edited on <?php echo $note_data->current->date;?> by <?php echo $note_data->current->author;?>
+                                                        </div>
+                                                    <?php endif; ?>
+
+                                                    <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+                                                        <button class="btn btn-primary edit-button pull-right" type="button">Edit</button>
+                                                    <?php endif; ?>
+
+
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <?php endif;?>
+
+                                    <?php reset($tracker_model); endforeach; ?>
+
+                                </table>
+
+
+
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+
+
+                <?php if ($this->session->userdata('permissions') == $permission_level) : ?>
+
+
+                        <?php if(!empty($office_campaign->tracker_status)): ?>
+                            <input type="hidden" name="reviewer_email" value="<?php if (!empty($office_campaign->tracker_status->reviewer_email)) echo  $office_campaign->tracker_status->reviewer_email ?>">
+                            <input type="hidden" name="status" value="<?php if (!empty($office_campaign->tracker_status->status)) echo  $office_campaign->tracker_status->status ?>">
+                        <?php endif; ?>
+
+                        <input type="hidden" name="office_id" value="<?php echo $office->id; ?>">
+                        <input type="hidden" name="status_id" value="<?php echo $office_campaign->status_id; ?>">
+                        <input type="hidden" name="milestone" value="<?php echo $milestone->selected_milestone; ?>">
+                    </form>
+                <?php endif; ?>
+
+            <?php
+                }
+           ?>
 
 
 <!-- ################################################################################ -->

--- a/application/views/office_list.php
+++ b/application/views/office_list.php
@@ -82,11 +82,11 @@ if($show_all_fields) {
 			if(!empty($omb_monitored_offices)) {
 
         if($show_all_fields) {
-          status_table_full('Other OMB-Monitored Agencies', $omb_monitored_offices, $tracker, $config, $milestone->selected_milestone, $milestone->specified);
+          status_table_full('Other Agencies', $omb_monitored_offices, $tracker, $config, $milestone->selected_milestone, $milestone->specified);
         } elseif ($show_qa_fields) {
-          status_table_qa('Other OMB-Monitored Agencies', $omb_monitored_offices, $tracker, $config, $section_breakdown, $milestone);
+          status_table_qa('Other Agencies', $omb_monitored_offices, $tracker, $config, $section_breakdown, $milestone);
         } else {
-          status_table('Other OMB-Monitored Agencies', $omb_monitored_offices, $tracker, $config, $section_breakdown, $milestone);
+          status_table('Other Agencies', $omb_monitored_offices, $tracker, $config, $section_breakdown, $milestone);
         }
 
 			}

--- a/application/views/office_table_inc_view.php
+++ b/application/views/office_table_inc_view.php
@@ -286,11 +286,17 @@ function status_table_qa($title, $rows, $tracker, $config = null, $sections_brea
 		<?php foreach ($rows as $office):?>
 
 		<?php
-			
+
 			if(!empty($office->datajson_status)) {
 				$office->datajson_status = json_decode($office->datajson_status);
 			}
 
+			// Initialize all the fields to empty
+			foreach ($model as $qa_field_name => $qa_field) {
+				$qa_field->value = '';
+			}
+
+			// If we were able to validate anything, show a summary
 			if(!empty($office->datajson_status->qa->validation_counts)) {
 
 				$error_count 		= (!empty($office->datajson_status->error_count)) ? $office->datajson_status->error_count : 0;
@@ -298,10 +304,10 @@ function status_table_qa($title, $rows, $tracker, $config = null, $sections_brea
 
 				$percent_valid		= (!empty($total_records)) ? process_percentage(($total_records - $error_count), $total_records) : '';
 
-				$model->last_modified->value 			= (!empty($office->datajson_status->filetime) && $office->datajson_status->filetime > 0) ? date("d-M-Y H:i:s T", $office->datajson_status->filetime) : '';
 				$model->last_crawl->value 				= date("d-M-Y H:i:s T", $office->datajson_status->last_crawl);
+				$model->last_modified->value 			= (!empty($office->datajson_status->filetime) && $office->datajson_status->filetime > 0) ? date("d-M-Y H:i:s T", $office->datajson_status->filetime) : '';
 				$model->total_records->value 			= $office->datajson_status->total_records;
-	    		$model->valid_count->value 				= $office->datajson_status->total_records - $office->datajson_status->error_count;
+				$model->valid_count->value 				= $office->datajson_status->total_records - $office->datajson_status->error_count;
 				$model->programs->value 				= count($office->datajson_status->qa->programCodes);
 				$model->bureaus->value 					= count($office->datajson_status->qa->bureauCodes);
 
@@ -315,19 +321,17 @@ function status_table_qa($title, $rows, $tracker, $config = null, $sections_brea
 				$model->accessURL_html->value 			= $office->datajson_status->qa->validation_counts->html;
 				$model->accessURL_pdf->value 			= $office->datajson_status->qa->validation_counts->pdf;
 
-				$accessURL_working_checksum = ($office->datajson_status->qa->validation_counts->http_5xx + 
-											  $office->datajson_status->qa->validation_counts->http_4xx + 
-											  $office->datajson_status->qa->validation_counts->http_3xx + 
-											  $office->datajson_status->qa->validation_counts->http_0);
+				$accessURL_working_checksum = ($office->datajson_status->qa->validation_counts->http_5xx +
+											$office->datajson_status->qa->validation_counts->http_4xx +
+											$office->datajson_status->qa->validation_counts->http_3xx +
+											$office->datajson_status->qa->validation_counts->http_0);
 
-				reset($model);	
+			} else if (!empty($model->last_crawl)) {
 
-			} else {
-				foreach ($model as $qa_field_name => $qa_field) {
-					$qa_field->value = '';
-				}
-				reset($model);	 
-			}	
+				// If we weren't able to validate anything, just show when the last crawl happened
+				$model->last_crawl->value = date("d-M-Y H:i:s T", $office->datajson_status->last_crawl);
+
+			}
 
 		?>
 

--- a/application/views/office_table_inc_view.php
+++ b/application/views/office_table_inc_view.php
@@ -244,7 +244,7 @@ function status_table($title, $rows, $tracker, $config = null, $sections_breakdo
 	</div>
 
 <?php
-} 
+}
 ?>
 
 
@@ -252,12 +252,18 @@ function status_table($title, $rows, $tracker, $config = null, $sections_breakdo
 <?php
 function status_table_qa($title, $rows, $tracker, $config = null, $sections_breakdown = null, $milestone = null) {
 
-	$model = $sections_breakdown;	
+	$model = $sections_breakdown;
 
 ?>
 
 	<table class="dashboard table table-striped table-hover table-bordered qa-table">
 
+		<tr class="dashboard-meta-heading">
+			<td><?php echo $title ?></td>
+			<td colspan="16">
+				Crawl Summary
+			</td>
+		</tr>
 		<tr class="dashboard-heading">
 			<th class="col-sm-3">		<div class="sr-only">Agency			</div></th>
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f93cf3d6a21578a440d7148b73950eca",
+    "content-hash": "d87a9cfe097892908e8b3f8da2af4036",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -4118,16 +4118,16 @@
         },
         {
             "name": "kenjis/ci-phpunit-test",
-            "version": "dev-patch-2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/GSA/ci-phpunit-test.git",
-                "reference": "84c82b6cd957f36da4df356fdee8bf6cf921adbc"
+                "url": "https://github.com/kenjis/ci-phpunit-test.git",
+                "reference": "cf331373ac5de475c7d31f4f635a6158fe42bfbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GSA/ci-phpunit-test/zipball/84c82b6cd957f36da4df356fdee8bf6cf921adbc",
-                "reference": "84c82b6cd957f36da4df356fdee8bf6cf921adbc",
+                "url": "https://api.github.com/repos/kenjis/ci-phpunit-test/zipball/cf331373ac5de475c7d31f4f635a6158fe42bfbd",
+                "reference": "cf331373ac5de475c7d31f4f635a6158fe42bfbd",
                 "shasum": ""
             },
             "require": {
@@ -4140,6 +4140,7 @@
                     "dev-master": "1.0.x-dev"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -4158,11 +4159,7 @@
                 "test",
                 "unit testing"
             ],
-            "support": {
-                "forum": "http://forum.codeigniter.com/thread-61725.html",
-                "source": "https://github.com/GSA/ci-phpunit-test/tree/patch-2"
-            },
-            "time": "2020-01-29T03:22:11+00:00"
+            "time": "2020-01-31T01:56:41+00:00"
         },
         {
             "name": "mikey179/vfsstream",


### PR DESCRIPTION
This change hides OMB reporting summary information in the presentation layer. It’s still there if OMB decides to reinstate that review process in future.