### PR TITLE
Isolate crawls to increase resilience

### DIFF
--- a/application/controllers/Campaign.php
+++ b/application/controllers/Campaign.php
@@ -27,20 +27,20 @@ class Campaign extends CI_Controller
 
 
     /**
-     * Index Page for this controller.
-     *
-     * Maps to the following URL
-     *        http://example.com/index.php/welcome
-     *    - or -
-     *        http://example.com/index.php/welcome/index
-     *    - or -
-     * Since this controller is set as the default controller in
-     * config/routes.php, it's displayed at http://example.com/
-     *
-     * So any other public methods not prefixed with an underscore will
-     * map to /index.php/welcome/<method_name>
-     * @see http://codeigniter.com/user_guide/general/urls.html
-     */
+    * Index Page for this controller.
+    *
+    * Maps to the following URL
+    *        http://example.com/index.php/welcome
+    *    - or -
+    *        http://example.com/index.php/welcome/index
+    *    - or -
+    * Since this controller is set as the default controller in
+    * config/routes.php, it's displayed at http://example.com/
+    *
+    * So any other public methods not prefixed with an underscore will
+    * map to /index.php/welcome/<method_name>
+    * @see http://codeigniter.com/user_guide/general/urls.html
+    */
     public function index()
     {
 
@@ -57,8 +57,8 @@ class Campaign extends CI_Controller
         $from_export = (!empty($from_export)) ? $from_export : $this->input->get('from_export', TRUE);
 
         if (!$orgs) {
-          show_error('Invalid orgs parameter, cannot be empty', 400);
-          return;
+            show_error('Invalid orgs parameter, cannot be empty', 400);
+            return;
         }
 
         $row_total = 100;
@@ -80,201 +80,201 @@ class Campaign extends CI_Controller
                 if ($from_export == 'true') break;
 
             } else {
-                break;
-            }
-
+            break;
         }
 
-        if (!empty($raw_data)) {
+    }
 
-            $json_schema = $this->campaign->datajson_schema();
-            $datajson_model = $this->campaign->schema_to_model($json_schema->items->properties);
+    if (!empty($raw_data)) {
 
-            $convert = array();
-            foreach ($raw_data as $ckan_data) {
-                $model = clone $datajson_model;
-                $convert[] = $this->campaign->datajson_crosswalk($ckan_data, $model);
-            }
+        $json_schema = $this->campaign->datajson_schema();
+        $datajson_model = $this->campaign->schema_to_model($json_schema->items->properties);
 
-            if ($this->environment == 'terminal') {
-                $filepath = 'export.json';
+        $convert = array();
+        foreach ($raw_data as $ckan_data) {
+            $model = clone $datajson_model;
+            $convert[] = $this->campaign->datajson_crosswalk($ckan_data, $model);
+        }
 
-                echo 'Creating file at ' . $filepath . PHP_EOL . PHP_EOL;
+        if ($this->environment == 'terminal') {
+            $filepath = 'export.json';
 
-                $export_file = fopen($filepath, 'w');
-                fwrite($export_file, json_encode($convert, JSON_PRETTY_PRINT));
-                fclose($export_file);
-            } else {
+            echo 'Creating file at ' . $filepath . PHP_EOL . PHP_EOL;
 
-                header('Content-type: application/json');
-                print json_encode($convert, JSON_PRETTY_PRINT);
-                exit;
-            }
-
+            $export_file = fopen($filepath, 'w');
+            fwrite($export_file, json_encode($convert, JSON_PRETTY_PRINT));
+            fclose($export_file);
         } else {
 
-            if ($this->environment == 'terminal') {
-                echo 'No results found for ' . $orgs;
-            } else {
-                header('Content-type: application/json');
-                print json_encode(array("error" => "no results"));
-                exit;
-            }
+            header('Content-type: application/json');
+            print json_encode($convert, JSON_PRETTY_PRINT);
+            exit;
         }
+
+    } else {
+
+        if ($this->environment == 'terminal') {
+            echo 'No results found for ' . $orgs;
+        } else {
+            header('Content-type: application/json');
+            print json_encode(array("error" => "no results"));
+            exit;
+        }
+    }
 
     }
 
     public function csv_to_json($schema = null)
     {
 
-        $schema = ($this->input->post('schema', TRUE)) ? $this->input->post('schema', TRUE) : $schema;
-        $csv_id = ($this->input->post('csv_id', TRUE)) ? $this->input->post('csv_id', TRUE) : null;
-        $prefix = 'fitara';
+    $schema = ($this->input->post('schema', TRUE)) ? $this->input->post('schema', TRUE) : $schema;
+    $csv_id = ($this->input->post('csv_id', TRUE)) ? $this->input->post('csv_id', TRUE) : null;
+    $prefix = 'fitara';
 
-        if (substr($schema, 0, strlen($prefix)) == $prefix) {
-            $prefix_model = substr($schema, strlen($prefix) + 1);
-        }
+    if (substr($schema, 0, strlen($prefix)) == $prefix) {
+        $prefix_model = substr($schema, strlen($prefix) + 1);
+    }
 
-        // Initial file upload
-        if (!empty($_FILES)) {
+    // Initial file upload
+    if (!empty($_FILES)) {
 
-            $this->load->library('upload');
+        $this->load->library('upload');
 
-            if ($this->do_upload('csv_upload')) {
+        if ($this->do_upload('csv_upload')) {
 
-                $data = $this->upload->data();
+            $data = $this->upload->data();
 
-                ini_set("auto_detect_line_endings", true);
-                $csv_handle = fopen($data['full_path'], 'r');
-                $headings = fgetcsv($csv_handle);
+            ini_set("auto_detect_line_endings", true);
+            $csv_handle = fopen($data['full_path'], 'r');
+            $headings = fgetcsv($csv_handle);
 
-                // Sanitize input
-                $headings = $this->security->xss_clean($headings);
+            // Sanitize input
+            $headings = $this->security->xss_clean($headings);
 
-                // Provide mapping between csv headings and POD schema
-                $this->load->model('campaign_model', 'campaign');
-                $json_schema = $this->campaign->datajson_schema($schema);
+            // Provide mapping between csv headings and POD schema
+            $this->load->model('campaign_model', 'campaign');
+            $json_schema = $this->campaign->datajson_schema($schema);
 
-                if ($schema) {
-                    if (!empty($prefix_model)) {
-                        $datajson_model = $this->campaign->schema_to_model($json_schema->properties->$prefix_model->items->properties);
-                    } else {
-                        $datajson_model = $this->campaign->schema_to_model($json_schema->properties->dataset->items->properties);
-                    }
+            if ($schema) {
+                if (!empty($prefix_model)) {
+                    $datajson_model = $this->campaign->schema_to_model($json_schema->properties->$prefix_model->items->properties);
                 } else {
-                    $datajson_model = $this->campaign->schema_to_model($json_schema->items->properties);
+                    $datajson_model = $this->campaign->schema_to_model($json_schema->properties->dataset->items->properties);
                 }
-
-                if (!$this->config->item('use_local_storage')) {
-                    $this->campaign->put_to_s3(
-                        $this->upload->upload_path . $data['file_name'],
-                        'uploads/' . $data['file_name']
-                    );
-                }
-
-                $output = array();
-                $output['headings'] = $headings;
-                $output['datajson_model'] = $datajson_model;
-                $output['csv_id'] = $data['file_name'];
-                $output['select_mapping'] = $this->csv_field_mapper($headings, $datajson_model);
-                $output['schema'] = $schema;
-                $this->load->view('csv_mapping', $output);
-
             } else {
-                $error = array('error' => $this->upload->display_errors());
-                if (defined('ENVIRONMENT') && ENVIRONMENT != 'production') {
-                    var_dump($error); exit;
-                }
+                $datajson_model = $this->campaign->schema_to_model($json_schema->items->properties);
             }
 
-        } // Apply mapping and convert file to JSON
-        else if (!empty($csv_id)) {
-
-            $csv_id = basename($csv_id);
-
-            $mapping = ($this->input->post('mapping', TRUE)) ? $this->input->post('mapping', TRUE) : null;
-            $schema = ($this->input->post('schema', TRUE)) ? $this->input->post('schema', TRUE) : 'federal';
-
-            $this->config->load('upload', TRUE);
-            $upload_config = $this->config->item('upload');
-
-            $full_path = $upload_config['upload_path'] . $csv_id;
-
-            $this->load->model('campaign_model', 'campaign');
-
-            if (!is_file($full_path) && !$this->config->item('use_local_storage')) {
-                $this->campaign->get_from_s3(
-                    'uploads/' . $csv_id,
-                    $full_path
+            if (!$this->config->item('use_local_storage')) {
+                $this->campaign->put_to_s3(
+                    $this->upload->upload_path . $data['file_name'],
+                    'uploads/' . $data['file_name']
                 );
             }
 
-            $this->load->helper('csv');
-            ini_set("auto_detect_line_endings", true);
+            $output = array();
+            $output['headings'] = $headings;
+            $output['datajson_model'] = $datajson_model;
+            $output['csv_id'] = $data['file_name'];
+            $output['select_mapping'] = $this->csv_field_mapper($headings, $datajson_model);
+            $output['schema'] = $schema;
+            $this->load->view('csv_mapping', $output);
 
-            $importer = new CsvImporter($full_path, $parse_header = true, $delimiter = ",");
-            $csv = $importer->get();
+        } else {
+            $error = array('error' => $this->upload->display_errors());
+            if (defined('ENVIRONMENT') && ENVIRONMENT != 'production') {
+                var_dump($error); exit;
+            }
+        }
 
-            $json = array();
+    } // Apply mapping and convert file to JSON
+    else if (!empty($csv_id)) {
 
-            if ($schema == 'federal-v1.1') {
+        $csv_id = basename($csv_id);
 
-                // Provide mapping between csv headings and POD schema
-                $json_schema = $this->campaign->datajson_schema($schema);
-                $datajson_model = $this->campaign->schema_to_model($json_schema->properties);
-                $datajson_model->dataset = array();
+        $mapping = ($this->input->post('mapping', TRUE)) ? $this->input->post('mapping', TRUE) : null;
+        $schema = ($this->input->post('schema', TRUE)) ? $this->input->post('schema', TRUE) : 'federal';
 
-                $dataset_model = clone $this->campaign->schema_to_model($json_schema->properties->dataset->items->properties);
-                $datasets = array();
+        $this->config->load('upload', TRUE);
+        $upload_config = $this->config->item('upload');
 
-                foreach ($csv as $row) {
+        $full_path = $upload_config['upload_path'] . $csv_id;
 
-                    $count = 0;
-                    $json_row = clone $dataset_model;
-                    $json_row->contactPoint = clone $dataset_model->contactPoint;
-                    $json_row->publisher = clone $dataset_model->publisher;
-                    $distribution_row = clone $dataset_model->distribution[0];
-                    foreach ($row as $key => $value) {
-                        if ($mapping[$count] !== 'null') {
+        $this->load->model('campaign_model', 'campaign');
 
-                            $value = $this->schema_map_filter($mapping[$count], $value, $schema);
+        if (!is_file($full_path) && !$this->config->item('use_local_storage')) {
+            $this->campaign->get_from_s3(
+                'uploads/' . $csv_id,
+                $full_path
+            );
+        }
 
-                            if (strpos($mapping[$count], '.') !== false) {
+        $this->load->helper('csv');
+        ini_set("auto_detect_line_endings", true);
 
-                                $field_path = explode('.', $mapping[$count]);
+        $importer = new CsvImporter($full_path, $parse_header = true, $delimiter = ",");
+        $csv = $importer->get();
 
-                                if (is_array($field_path) && array_key_exists($field_path[0], $json_row) && array_key_exists($field_path[1], $json_row->$field_path[0])) {
-                                    $json_row->$field_path[0]->$field_path[1] = $value;
-                                }
+        $json = array();
 
-                                if ($field_path[0] == 'distribution') {
-                                    if (array_key_exists($field_path[1], $distribution_row)) {
-                                        $distribution_row->$field_path[1] = $value;
-                                    }
-                                }
+        if ($schema == 'federal-v1.1') {
 
+            // Provide mapping between csv headings and POD schema
+            $json_schema = $this->campaign->datajson_schema($schema);
+            $datajson_model = $this->campaign->schema_to_model($json_schema->properties);
+            $datajson_model->dataset = array();
+
+            $dataset_model = clone $this->campaign->schema_to_model($json_schema->properties->dataset->items->properties);
+            $datasets = array();
+
+            foreach ($csv as $row) {
+
+                $count = 0;
+                $json_row = clone $dataset_model;
+                $json_row->contactPoint = clone $dataset_model->contactPoint;
+                $json_row->publisher = clone $dataset_model->publisher;
+                $distribution_row = clone $dataset_model->distribution[0];
+                foreach ($row as $key => $value) {
+                    if ($mapping[$count] !== 'null') {
+
+                        $value = $this->schema_map_filter($mapping[$count], $value, $schema);
+
+                        if (strpos($mapping[$count], '.') !== false) {
+
+                            $field_path = explode('.', $mapping[$count]);
+
+                            if (is_array($field_path) && array_key_exists($field_path[0], $json_row) && array_key_exists($field_path[1], $json_row->$field_path[0])) {
+                                $json_row->$field_path[0]->$field_path[1] = $value;
                             }
 
-                            if (array_key_exists($mapping[$count], $json_row)) {
-                                $json_row->$mapping[$count] = $value;
+                            if ($field_path[0] == 'distribution') {
+                                if (array_key_exists($field_path[1], $distribution_row)) {
+                                    $distribution_row->$field_path[1] = $value;
+                                }
                             }
 
                         }
 
-                        $count++;
+                        if (array_key_exists($mapping[$count], $json_row)) {
+                            $json_row->$mapping[$count] = $value;
+                        }
+
                     }
-                    $json_row->distribution = array($distribution_row);
-                    $this->campaign->unset_nulls($json_row);
-                    $datasets[] = $json_row;
 
+                    $count++;
                 }
+                $json_row->distribution = array($distribution_row);
+                $this->campaign->unset_nulls($json_row);
+                $datasets[] = $json_row;
 
-                $id_field = '@id';
-                $context_field = '@context';
-                unset($datajson_model->$id_field);
+            }
 
-                $datajson_model->$context_field = 'https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld';
-                $datajson_model->conformsTo = 'https://project-open-data.cio.gov/v1.1/schema';
+            $id_field = '@id';
+            $context_field = '@context';
+            unset($datajson_model->$id_field);
+
+            $datajson_model->$context_field = 'https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld';
+            $datajson_model->conformsTo = 'https://project-open-data.cio.gov/v1.1/schema';
                 $datajson_model->describedBy = 'https://project-open-data.cio.gov/v1.1/schema/catalog.json';
 
                 $datajson_model->dataset = $datasets;
@@ -361,180 +361,180 @@ class Campaign extends CI_Controller
             $field = html_escape($field);
             ?>
             <div class="form-group">
-                <label class="col-sm-2" for="<?php echo $field; ?>"><?php echo $field; ?></label>
-                <div class="col-sm-3">
-                    <select id="<?php echo $field; ?>" type="text" name="mapping[<?php echo $count; ?>]">
-                        <option value="null">Select a corresponding field</option>
-                        <?php //var_dump($datajson_model); ?>
-                        <?php foreach ($datajson_model as $pod_field => $pod_value): ?>
-                            <?php
+            <label class="col-sm-2" for="<?php echo $field; ?>"><?php echo $field; ?></label>
+            <div class="col-sm-3">
+            <select id="<?php echo $field; ?>" type="text" name="mapping[<?php echo $count; ?>]">
+            <option value="null">Select a corresponding field</option>
+            <?php //var_dump($datajson_model); ?>
+            <?php foreach ($datajson_model as $pod_field => $pod_value): ?>
+                <?php
 
-                            if (is_object($pod_value) OR (is_array($pod_value) && count($pod_value) > 0)) {
+                if (is_object($pod_value) OR (is_array($pod_value) && count($pod_value) > 0)) {
 
-                                foreach ($pod_value as $parent_field => $pod_value_child) {
+                    foreach ($pod_value as $parent_field => $pod_value_child) {
 
-                                    if (is_object($pod_value_child)) {
-                                        foreach ($pod_value_child as $child_field => $child_value) {
+                        if (is_object($pod_value_child)) {
+                            foreach ($pod_value_child as $child_field => $child_value) {
 
-                                            if (strtolower(trim($field)) == strtolower(trim("$pod_field.$child_field")) && !$matched[$field]) {
-                                                $selected = 'selected="selected"';
-                                                $match = true;
-                                            } else {
-                                                $selected = '';
-                                            }
-                                            ?>
-
-                                            <option value="<?php echo "$pod_field.$child_field" ?>" <?php echo $selected ?>><?php echo $pod_field . ' - ' . $child_field ?></option>
-
-                                            <?php
-                                            if ($match) {
-                                                $match = false;
-                                                $selected = '';
-                                                $matched[$field] = true;
-                                            }
-
-                                        }
-                                    } else {
-                                        if (strtolower(trim($field)) == strtolower(trim("$pod_field.$parent_field")) && !$matched[$field]) {
-                                            $selected = 'selected="selected"';
-                                            $match = true;
-                                        } else {
-                                            $selected = '';
-                                        }
-                                        ?>
-
-                                        <option value="<?php echo "$pod_field.$parent_field" ?>" <?php echo $selected ?>><?php echo $pod_field . ' - ' . $parent_field ?></option>
-
-                                        <?php
-                                        if ($match) {
-                                            $match = false;
-                                            $selected = '';
-                                            $matched[$field] = true;
-                                        }
-                                    }
-
-                                }
-
-
-                            } else {
-
-                                if (strtolower(trim($field)) == strtolower(trim($pod_field)) && !isset($matched[$field])) {
+                                if (strtolower(trim($field)) == strtolower(trim("$pod_field.$child_field")) && !$matched[$field]) {
                                     $selected = 'selected="selected"';
                                     $match = true;
                                 } else {
                                     $selected = '';
                                 }
+                                ?>
 
+                                <option value="<?php echo "$pod_field.$child_field" ?>" <?php echo $selected ?>><?php echo $pod_field . ' - ' . $child_field ?></option>
+
+                                <?php
+                                if ($match) {
+                                    $match = false;
+                                    $selected = '';
+                                    $matched[$field] = true;
+                                }
 
                             }
-
+                        } else {
+                            if (strtolower(trim($field)) == strtolower(trim("$pod_field.$parent_field")) && !$matched[$field]) {
+                                $selected = 'selected="selected"';
+                                $match = true;
+                            } else {
+                                $selected = '';
+                            }
                             ?>
-                            <option value="<?php echo $pod_field ?>" <?php echo $selected ?>><?php echo $pod_field ?></option>
-                            <?php
 
+                            <option value="<?php echo "$pod_field.$parent_field" ?>" <?php echo $selected ?>><?php echo $pod_field . ' - ' . $parent_field ?></option>
+
+                            <?php
                             if ($match) {
                                 $match = false;
                                 $selected = '';
                                 $matched[$field] = true;
                             }
+                        }
+
+                    }
 
 
-                            ?>
-                        <?php endforeach; ?>
-                    </select>
+                } else {
+
+                    if (strtolower(trim($field)) == strtolower(trim($pod_field)) && !isset($matched[$field])) {
+                        $selected = 'selected="selected"';
+                        $match = true;
+                    } else {
+                        $selected = '';
+                    }
+
+
+                }
+
+                ?>
+                <option value="<?php echo $pod_field ?>" <?php echo $selected ?>><?php echo $pod_field ?></option>
+                <?php
+
+                if ($match) {
+                    $match = false;
+                    $selected = '';
+                    $matched[$field] = true;
+                }
+
+
+                ?>
+                <?php endforeach; ?>
+                </select>
                 </div>
                 <div class="col-sm-2">
-                    <?php
-                    if (!($match OR (isset($matched[$field]) && isset($matched[$field])))) echo '<span class="text-danger">No match found</span>';
-                    $match = false;
-                    $count++;
-                    ?>
+                <?php
+                if (!($match OR (isset($matched[$field]) && isset($matched[$field])))) echo '<span class="text-danger">No match found</span>';
+                $match = false;
+                $count++;
+                ?>
                 </div>
-            </div>
-            <?php
-            reset($datajson_model);
+                </div>
+                <?php
+                reset($datajson_model);
+            }
+
+            return ob_get_clean();
+
         }
 
-        return ob_get_clean();
+        public function schema_map_filter($field, $value, $schema = null)
+        {
 
-    }
-
-    public function schema_map_filter($field, $value, $schema = null)
-    {
-
-        if (is_json($value)) {
-            $value = json_decode($value);
-        } else if ($field == 'keyword' |
+            if (is_json($value)) {
+                $value = json_decode($value);
+            } else if ($field == 'keyword' |
             $field == 'language' |
             $field == 'references' |
             $field == 'theme' |
             $field == 'programCode' |
             $field == 'bureauCode'
-        ) {
-            $value = str_getcsv($value);
-        } else if ($field == 'dataQuality' && !empty($value)) {
-            $value = (bool)$value;
+            ) {
+                $value = str_getcsv($value);
+            } else if ($field == 'dataQuality' && !empty($value)) {
+                $value = (bool)$value;
+            }
+
+            if (is_array($value)) {
+                $value = array_map("make_utf8", $value);
+                $value = array_map("trim", $value);
+                $value = array_filter($value); // removes any empty elements in an array
+                $value = array_values($value); // ensures array_filter doesn't create an associative array
+            } else if (is_string($value)) {
+                $value = trim($value);
+                $value = make_utf8($value);
+            }
+
+            $value = (!is_bool($value) && empty($value)) ? null : $value;
+
+            return $value;
+
         }
 
-        if (is_array($value)) {
-            $value = array_map("make_utf8", $value);
-            $value = array_map("trim", $value);
-            $value = array_filter($value); // removes any empty elements in an array
-            $value = array_values($value); // ensures array_filter doesn't create an associative array
-        } else if (is_string($value)) {
-            $value = trim($value);
-            $value = make_utf8($value);
-        }
+        public function csv($orgs = null)
+        {
+            $this->load->model('campaign_model', 'campaign');
 
-        $value = (!is_bool($value) && empty($value)) ? null : $value;
+            if ($orgs == 'all') {
+                $orgs = '*';
+            }
 
-        return $value;
+            if (empty($orgs)) {
+                $orgs = $this->input->get('orgs', TRUE);
+            }
 
-    }
-
-    public function csv($orgs = null)
-    {
-        $this->load->model('campaign_model', 'campaign');
-
-        if ($orgs == 'all') {
-            $orgs = '*';
-        }
-
-        if (empty($orgs)) {
-            $orgs = $this->input->get('orgs', TRUE);
-        }
-
-        if (empty($orgs)) {
-            $geospatial = $this->input->get('geospatial', TRUE);
-        } else {
-            $geospatial = false;
-        }
-
-        // if we didn't get any requests, bail
-        if (empty($orgs)) {
-            show_404($orgs, false);
-            exit;
-        }
-
-        $row_total = 100;
-        $row_count = 0;
-
-        $row_pagesize = 500;
-        $raw_data = array();
-
-        while ($row_count < $row_total) {
-            $result = $this->campaign->get_datagov_json($orgs, $geospatial, $row_pagesize, $row_count, true);
-
-            if (!empty($result)) {
-                $row_total = $result->result->count;
-                $row_count = $row_count + $row_pagesize;
-
-                if ($this->environment == 'terminal' OR $this->environment == 'cron') {
-                    echo 'Exporting ' . $row_count . ' of ' . $row_total . PHP_EOL;
-                }
-
-                $raw_data = array_merge($raw_data, $result->result->results);
+            if (empty($orgs)) {
+                $geospatial = $this->input->get('geospatial', TRUE);
             } else {
+                $geospatial = false;
+            }
+
+            // if we didn't get any requests, bail
+            if (empty($orgs)) {
+                show_404($orgs, false);
+                exit;
+            }
+
+            $row_total = 100;
+            $row_count = 0;
+
+            $row_pagesize = 500;
+            $raw_data = array();
+
+            while ($row_count < $row_total) {
+                $result = $this->campaign->get_datagov_json($orgs, $geospatial, $row_pagesize, $row_count, true);
+
+                if (!empty($result)) {
+                    $row_total = $result->result->count;
+                    $row_count = $row_count + $row_pagesize;
+
+                    if ($this->environment == 'terminal' OR $this->environment == 'cron') {
+                        echo 'Exporting ' . $row_count . ' of ' . $row_total . PHP_EOL;
+                    }
+
+                    $raw_data = array_merge($raw_data, $result->result->results);
+                } else {
                 break;
             }
 
@@ -785,44 +785,7 @@ class Campaign extends CI_Controller
                 $offices = $this->campaign->prioritize_crawl($offices, $milestone->current);
             }
 
-            // We don't want child processes to have access to our DB connection descriptor or they'll close it down when they exit.
-            // So we close it pre-emptively here.
-            $this->db->close();
-
-            foreach ($offices as $office) {
-
-                // Since we're dealing with externally-supplied content, let's
-                // do our crawl in a sub-process to guard against anything that
-                // might crashes us.
-                $pid = pcntl_fork();
-                if ($pid == -1) {
-
-                    die('could not fork');
-
-                } else if ($pid) {
-
-                    // This logic is only hit in the parent process
-                    $status = null;
-                    echo "Waiting on process ".$pid."\n";
-                    pcntl_waitpid($pid, $status); //Protect against Zombie children
-                    echo "Process ".$pid." exited with status ".(pcntl_wifexited($status)?pcntl_wexitstatus($status):"-1").".\n";
-                    continue;
-
-                } else {
-
-                    // This logic is only hit in the child process
-
-                    // The child process needs its own connection to the database
-                    $this->load->database();
-                    $this->status_single_office($office, $component, $selected_milestone, $url_override);
-                    exit;
-
-                }
-
-            }
-
-            // Done with forking, so get the parent connection to the DB restarted
-            $this->load->database();
+            $this->status_offices($offices, $component, $selected_milestone, $url_override);
 
             // Close file connections that are still open
             if (is_resource($this->campaign->validation_log)) {
@@ -837,6 +800,68 @@ class Campaign extends CI_Controller
 
     }
 
+    public function status_offices($offices, $component, $selected_milestone, $url_override) {
+
+        /*
+        *
+        * Since we're dealing with externally-hosted content, let's
+        * guard against anything that might crashes the process and halt the crawl.
+        *
+        * The body of this method is a version of this loop, but with each office handled in a sub-process:
+        *
+        *   foreach ($offices as $office) {
+        *         $this->status_single_office($office, $component, $selected_milestone, $url_override);
+        *   }
+        *
+        */
+
+        // We don't want child processes to have access to our DB connection descriptor or they'll close it down when they exit.
+        // So before we start forking, we close it pre-emptively here.
+        $this->db->close();
+
+        foreach ($offices as $office) {
+
+            $pid = pcntl_fork();
+            if ($pid == -1) {
+
+                die('could not fork');
+
+            } else if ($pid) {
+
+                // This logic is only hit in the PARENT process
+
+                $status = null;
+                echo "Waiting on child process ".$pid."\n";
+                pcntl_waitpid($pid, $status);
+
+                // If the process exited normally, show that status, otherwise just use -1 to indicate failure
+                $status = pcntl_wifexited($status) ? pcntl_wexitstatus($status) : "-1";
+                echo "Child process ".$pid." exited with status ".$status.".\n";
+
+                // We handed off responsibility for this office to the child; skip to the next office!
+                continue;
+
+            } else {
+
+                // This logic is only hit in the CHILD process
+
+                // The child process needs its own connection to the database to report in when it finishes
+                $this->load->database();
+
+                // Process the office
+                $this->status_single_office($office, $component, $selected_milestone, $url_override);
+
+                // Once the child has reported its status, it can end normally.
+                exit(0);
+
+            }
+
+        }
+
+        // We're done with forking, so get the parent connection to the DB restarted
+        $this->load->database();
+
+    }
 
     public function status_single_office($office, $component, $selected_milestone, $url_override)
     {
@@ -1386,13 +1411,13 @@ class Campaign extends CI_Controller
 
             $datajson_domain = parse_url($datajson_new);
             if ($datajson_domain === false) {
-              show_error('datajson_new parameter is not a valid URL.', 400);
-              return;
+                show_error('datajson_new parameter is not a valid URL.', 400);
+                return;
             }
 
             if ($datajson_domain['scheme'] !== 'http' || $datajson_domain['scheme'] !== 'https') {
-              show_error('datajson_new must be an http(s) URL.', 400);
-              return;
+                show_error('datajson_new must be an http(s) URL.', 400);
+                return;
             }
 
             $output['datajson_domain'] = $datajson_domain['host'];
@@ -1562,7 +1587,7 @@ class Campaign extends CI_Controller
                 } else {
                     //                Add sub id to existing agency entry, e.g. [id,sub_id1,sub_id2] or [,sub_id1,sub_id2]
                     $return[$taxonomy['vocabulary']][$taxonomy['Federal Agency']]['id']
-                        = "[" . trim($return[$taxonomy['vocabulary']][$taxonomy['Federal Agency']]['id'], "[]") . "," . $taxonomy['unique id'] . "]";
+                    = "[" . trim($return[$taxonomy['vocabulary']][$taxonomy['Federal Agency']]['id'], "[]") . "," . $taxonomy['unique id'] . "]";
                 }
 
                 //            Add term to parent's subs
@@ -1661,63 +1686,92 @@ class Campaign extends CI_Controller
                     unset($datajson_model->$id);
                     $datajson_model->$context = 'https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld';
                     $datajson_model->conformsTo = 'https://project-open-data.cio.gov/v1.1/schema';
-                    $datajson_model->describedBy = 'https://project-open-data.cio.gov/v1.1/schema/catalog.json';
+                        $datajson_model->describedBy = 'https://project-open-data.cio.gov/v1.1/schema/catalog.json';
 
-                    $datajson_model->dataset = $convert;
+                        $datajson_model->dataset = $convert;
 
 
-                    // provide json for download
-                    header("Pragma: public");
-                    header("Expires: 0");
-                    header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-                    header("Cache-Control: private", false);
-                    header('Content-type: application/json');
-                    header("Content-Disposition: attachment; filename=\"$filename\";");
-                    header("Content-Transfer-Encoding: binary");
+                        // provide json for download
+                        header("Pragma: public");
+                        header("Expires: 0");
+                        header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+                        header("Cache-Control: private", false);
+                        header('Content-type: application/json');
+                        header("Content-Disposition: attachment; filename=\"$filename\";");
+                        header("Content-Transfer-Encoding: binary");
 
-                    print json_encode($datajson_model, JSON_PRETTY_PRINT);
-                    exit;
+                        print json_encode($datajson_model, JSON_PRETTY_PRINT);
+                        exit;
+                    } else {
+                        $data = array();
+                        $data['errors'] = 'The file was not valid JSON';
+                        $this->load->view('upgrade_schema', $data);
+                    }
+
+
+                }
+            } else {
+                $this->load->view('upgrade_schema');
+            }
+
+
+        }
+
+        /*
+        Crawl each record in a datajson file and save current version + validation results
+        */
+
+        public function version_datajson($office_id = null)
+        {
+
+
+            $this->load->model('campaign_model', 'campaign');
+
+
+            // look up last crawl cycle for this office id
+            if (!empty($office_id)) {
+
+                $current_crawl = $this->campaign->datajson_crawl();
+                $current_crawl->office_id = $office_id;
+
+                if ($last_crawl = $this->campaign->get_datajson_crawl($current_crawl->office_id)) {
+
+                    // make sure last crawl completed
+                    if ($last_crawl->crawl_status == 'completed' && !empty($last_crawl->crawl_end)) {
+                        $current_crawl->crawl_cycle = $last_crawl->crawl_cycle + 1;
+                    } else {
+                        // abort
+                        $current_crawl->crawl_cycle = $last_crawl->crawl_cycle;
+                        $current_crawl->crawl_status = 'aborted';
+
+                        // save crawl status
+                        $this->campaign->save_datajson_crawl($current_crawl);
+
+                        return $current_crawl;
+
+                    }
+
                 } else {
-                    $data = array();
-                    $data['errors'] = 'The file was not valid JSON';
-                    $this->load->view('upgrade_schema', $data);
+                    $last_crawl = false;
+                    $current_crawl->crawl_cycle = 1;
                 }
 
 
-            }
-        } else {
-            $this->load->view('upgrade_schema');
-        }
+                $current_crawl->crawl_status = 'started';
+
+                // save crawl status
+                $this->campaign->save_datajson_crawl($current_crawl);
 
 
-    }
+                if ($current_crawl->crawl_status == 'started') {
 
-    /*
-    Crawl each record in a datajson file and save current version + validation results
-    */
+                    // check to see if datajson status is good enough to parse
 
-    public function version_datajson($office_id = null)
-    {
+                    // ******** missing code here
 
-
-        $this->load->model('campaign_model', 'campaign');
-
-
-        // look up last crawl cycle for this office id
-        if (!empty($office_id)) {
-
-            $current_crawl = $this->campaign->datajson_crawl();
-            $current_crawl->office_id = $office_id;
-
-            if ($last_crawl = $this->campaign->get_datajson_crawl($current_crawl->office_id)) {
-
-                // make sure last crawl completed
-                if ($last_crawl->crawl_status == 'completed' && !empty($last_crawl->crawl_end)) {
-                    $current_crawl->crawl_cycle = $last_crawl->crawl_cycle + 1;
-                } else {
-                    // abort
-                    $current_crawl->crawl_cycle = $last_crawl->crawl_cycle;
-                    $current_crawl->crawl_status = 'aborted';
+                    foreach ($metadata_records as $metadata_record) {
+                        $this->version_metadata_record($current_crawl);
+                    }
 
                     // save crawl status
                     $this->campaign->save_datajson_crawl($current_crawl);
@@ -1726,32 +1780,6 @@ class Campaign extends CI_Controller
 
                 }
 
-            } else {
-                $last_crawl = false;
-                $current_crawl->crawl_cycle = 1;
-            }
-
-
-            $current_crawl->crawl_status = 'started';
-
-            // save crawl status
-            $this->campaign->save_datajson_crawl($current_crawl);
-
-
-            if ($current_crawl->crawl_status == 'started') {
-
-                // check to see if datajson status is good enough to parse
-
-                // ******** missing code here
-
-                foreach ($metadata_records as $metadata_record) {
-                    $this->version_metadata_record($current_crawl);
-                }
-
-                // save crawl status
-                $this->campaign->save_datajson_crawl($current_crawl);
-
-                return $current_crawl;
 
             }
 
@@ -1760,6 +1788,3 @@ class Campaign extends CI_Controller
 
 
     }
-
-
-}


### PR DESCRIPTION
It's possible that a crawl could result in the PHP process hitting its memory limit and exiting unexpectedly. This change runs each crawl in a forked sub-process, so that if the crawl dies unexpectedly, the overall crawl can carry on.
