### PR TITLE
Enable PCTRL extension via PHP buildpack

### DIFF
--- a/.bp-config/php/php.ini.d/dashboard.ini
+++ b/.bp-config/php/php.ini.d/dashboard.ini
@@ -1,1 +1,2 @@
 extension=mysqli.so
+extension=pcntl.so


### PR DESCRIPTION
In order for scans to run in a sub-process, the PCTRL extension must be enabled. It's not enabled by default in cloud.gov, so this PR turns it on. (Already tested by manually pushing this branch.)﻿
