### PR TITLE
Expect app-specific-service names

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,9 +5,9 @@ default_config: &defaults
   disk_quota: 512M
   timeout: 180
   services:
-    - database # cf create-service aws-rds shared-mysql database
-    - s3       # cf create-service s3 basic s3
-    - secrets  # cf create-user-provided-service secrets -p '{
+    - dashboard-db       # cf create-service aws-rds shared-mysql dashboard-db
+    - dashboard-s3       # cf create-service s3 basic dashboard-s3
+    - dashboard-secrets  # cf create-user-provided-service dashboard-secrets -p '{
                # "ENCRYPTION_KEY": "long-random-string"
                # }'
 


### PR DESCRIPTION
Since the dashboard app will coexist with other apps in various spaces, we should disambiguate the names of the services that are provisioned.