### PR TITLE
Increase timeout for downloading data.json

### DIFF
--- a/application/controllers/Campaign.php
+++ b/application/controllers/Campaign.php
@@ -1033,7 +1033,7 @@ class Campaign extends CI_Controller
                         echo 'Resource ' . $real_url . ' not available' . PHP_EOL;
                     }
 
-                    exit;
+                    return;
 
                 } else {
                     // download and version this data.json file.

--- a/application/helpers/api_helper.php
+++ b/application/helpers/api_helper.php
@@ -5,28 +5,28 @@ function curl_from_json($url, $array=false, $decode=true) {
 	$ch = curl_init();
     curl_setopt($ch, CURLOPT_USERAGENT,'Data.gov data.json crawler');
 	curl_setopt($ch, CURLOPT_URL, $url);
-	
+
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);	
-	
+	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+
     curl_setopt($ch, CURLOPT_FRESH_CONNECT, true);
     curl_setopt($ch, CURLOPT_FILETIME, true);
-    
-    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET'); 
-    
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+
     curl_setopt($ch, CURLOPT_COOKIESESSION, true);
     curl_setopt($ch, CURLOPT_COOKIE, "");
-    
+
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch, CURLOPT_MAXREDIRS, 10);    
-    
+    curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
+
 
 	$data=curl_exec($ch);
 	curl_close($ch);
 
     if($decode == true) {
       $data = iconv('UTF-8', 'UTF-8//IGNORE', utf8_encode($data));
-	    return json_decode($data, $array);	        
+	    return json_decode($data, $array);
     } else {
         return $data;
     }
@@ -42,23 +42,23 @@ function curl_header($url, $follow_redirect = true, $tmp_dir = null, $force_shim
   }
 
   $info = array();
-  
+
   $ch = curl_init();
 
   curl_setopt($ch, CURLOPT_USERAGENT,'Data.gov data.json crawler');
   curl_setopt($ch, CURLOPT_URL, $url);
 
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);  
+  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 
-  curl_setopt($ch, CURLOPT_TIMEOUT, 10);  
+  curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 
   curl_setopt($ch, CURLOPT_FRESH_CONNECT, true);
   curl_setopt($ch, CURLOPT_FILETIME, true);
 
   curl_setopt($ch, CURLOPT_NOBODY, true);
   curl_setopt($ch, CURLOPT_HEADER, true);
-  
+
   curl_setopt($ch, CURLOPT_COOKIESESSION, true);
   curl_setopt($ch, CURLOPT_COOKIE, "");
 
@@ -72,9 +72,9 @@ function curl_header($url, $follow_redirect = true, $tmp_dir = null, $force_shim
   curl_close($ch);
 
 
-  // If the server didn't support HTTP HEAD, use the shim. 
+  // If the server didn't support HTTP HEAD, use the shim.
   if( (!empty($info['header']['X-Error-Message']) && trim($info['header']['X-Error-Message']) == 'HEAD is not supported')
-      OR empty($info['header']['Content-Type'])) {   
+      OR empty($info['header']['Content-Type'])) {
     return curl_head_shim($url, $follow_redirect, $tmp_dir);
   } else {
     return $info;
@@ -99,8 +99,8 @@ function curl_head_shim($url, $follow_redirect = true, $tmp_dir = '') {
   curl_setopt($ch, CURLOPT_FILE, $output);
 
   curl_setopt($ch, CURLOPT_WRITEHEADER, $headerfile);
-  curl_setopt($ch, CURLOPT_TIMEOUT, 3); 
-  curl_setopt($ch, CURLOPT_HEADER, true); 
+  curl_setopt($ch, CURLOPT_TIMEOUT, 6);
+  curl_setopt($ch, CURLOPT_HEADER, true);
 
   curl_setopt($ch, CURLOPT_USERAGENT,'Data.gov data.json crawler');
 
@@ -287,7 +287,7 @@ function filter_json( $source_datajson, $dataset_array = false ) {
 
       if (is_string($field_value)) {
         $field_value =  filter_var( $field_value, FILTER_SANITIZE_STRING );
-      } 
+      }
 
       $dataset->$field_name = $field_value;
 
@@ -301,7 +301,7 @@ function filter_json( $source_datajson, $dataset_array = false ) {
     $source_datajson = $datasets;
   }
 
-    return $source_datajson; 
+    return $source_datajson;
 }
 
 


### PR DESCRIPTION
An agency wanted to know why their crawls weren't succeeding after they fixed a redirect on their side. I found that with three redirects in the chain and a large data.json file at the end, libcurl was timing out before the final request was completed, so the third (but not final) request's headers were recorded (status 301) rather than the fourth (status 200).