### PR TITLE
Fix cloud.gov deploy

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,5 @@
 ---
 default_config: &defaults
-  buildpacks:
-    - php_buildpack
   disk_quota: 512M
   timeout: 180
   services:


### PR DESCRIPTION
Our CI deployment uses an extension (`autopilot`) that relies on an outmoded `cf push` mechanism that can't handle the newer `buildpacks` attribute. However, the attribute is unnecessary since automatic buildpack detection does the right thing in any case.
