### PR TITLE
Ensure the PCNTL extension is enabled

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN a2enmod rewrite
 
 # Install php extensions
 RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install pcntl
 
 # Install composer
 COPY docker/install-composer.sh /tmp/install-composer.sh


### PR DESCRIPTION
Process control functions are used to enable crawls to run in sub-processes so they won't starve out the main process if they run out of memory.