### PR TITLE
Silence PHP warning/notices

### DIFF
--- a/application/controllers/Offices.php
+++ b/application/controllers/Offices.php
@@ -445,8 +445,8 @@ class Offices extends CI_Controller {
 					if (is_numeric($value) OR strpos($value, '%') !== false) {
 
 						if (strpos($value, '%') !== false) {
-							if(empty($totals[$field]['type'])) $totals[$field]['type'] = 'percent';
-							$value = $value * 0.01;
+                            if(empty($totals[$field]['type'])) $totals[$field]['type'] = 'percent';
+                            	$value = floatval($value) * 0.01;
 
 							if($totals[$field]['type'] == 'integer') {
 								$totals[$field]['errors'] .= 'Inconsistent data type found on ' . $office->id . ' ';

--- a/application/views/office_table_inc_view.php
+++ b/application/views/office_table_inc_view.php
@@ -326,7 +326,7 @@ function status_table_qa($title, $rows, $tracker, $config = null, $sections_brea
 											$office->datajson_status->qa->validation_counts->http_3xx +
 											$office->datajson_status->qa->validation_counts->http_0);
 
-			} else if (!empty($model->last_crawl)) {
+			} else if (!empty($model->last_crawl) && !empty($office->datajson_status) && isset($office->datajson_status->last_crawl)) {
 
 				// If we weren't able to validate anything, just show when the last crawl happened
 				$model->last_crawl->value = date("d-M-Y H:i:s T", $office->datajson_status->last_crawl);


### PR DESCRIPTION
Certain edge conditions are hit due to strange data in older reports (eg what you see currently at https://labs.data.gov/dashboard/offices/2014-05-31/qa ) which don't occur in any new reports. These changes just avoid those edge conditions.
