### PR TITLE
[cd] always notify

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     }
   }
   post {
-    failure {
+    always {
       step([$class: 'GitHubIssueNotifier', issueAppend: true])
     }
   }


### PR DESCRIPTION
This allows Jenkins to close failed build issues once a successful build
happens.