### PR TITLE
Controller cleanup

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -10,7 +10,6 @@ $project_shared_path = getenv('PROJECT_SHARED_PATH') ?: realpath(APPPATH . '..')
 $config['project_shared_path'] = $project_shared_path;
 $config['download_dir'] = $project_shared_path . '/downloads';
 $config['archive_dir'] = $project_shared_path . '/archive';
-$config['docs_path'] = 'https://raw.githubusercontent.com/GSA/project-open-data-dashboard/master/documentation/';
 
 $config['s3_bucket'] = getenv('S3_BUCKET') ?: '';
 $config['s3_prefix'] = getenv('S3_PREFIX') ?: '';

--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -49,14 +49,10 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | Examples:	my-controller/index	-> my_controller/index
 |		my-controller/my-method	-> my_controller/my_method
 */
-$route['default_controller'] = 'docs/routes';
+$route['default_controller'] = 'offices/qa';
 $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;
 
-$route['healthcheck'] = 'healthcheck/index';
-
-$route['export'] = "docs/routes/export";
-$route['merge'] = "docs/merge";
 $route['upgrade-schema'] = "campaign/upgrade_schema";
 
 $route['digitalstrategy'] = "campaign/digitalstrategy";
@@ -67,26 +63,13 @@ $route['changeset'] = "campaign/changeset";
 $route['datagov/status-update'] = "campaign/status_update";
 $route['datagov/status-review-update'] = "campaign/status_review_update";
 
-
 $route['datagov/(:any)']                = "campaign/$1";
 $route['datagov/(:any)/']               = "campaign/$1";
 $route['datagov/(:any)/(:any)']         = "campaign/$1/$2";
 $route['datagov/(:any)/(:any)/(:any)']  = "campaign/$1/$2/$3";
 
-$route['offices/all']       = "offices/routes/all";
-$route['offices/detail']    = "offices/routes/detail";
-$route['offices/qa']        = "offices/routes/qa";
+$route['docs/(:any)']       = "docs/index/$1";
 
 // Specific date reports (of the form Y-m-d) can have up to four parameters
 $route['offices/(\d{4}-\d{2}-\d{2})/?(:any)?/?(:any)?/?(:any)?/?(:any)?'] =
-    "offices/routes/$1/$2/$3/$4";
-
-// "Special" doc pages
-$route['docs/(intro|export|user)']  = "docs/routes/$1";
-
-// Search for a file named `$1.md` to transform)
-$route['docs/(:any)']               = "docs/routes/$1";
-
-//$route['login'] = "auth/session/github";
-$route['logout'] = "user/logout";
-$route['account'] = "docs/routes/user";
+    "offices/milestone/$1/$2/$3/$4";

--- a/application/controllers/Docs.php
+++ b/application/controllers/Docs.php
@@ -61,29 +61,4 @@ class Docs extends CI_Controller {
 		$this->load->view('docs', $data);
 	}
 
-
-	public function routes($route = 'intro') {
-
-		if ($route == 'intro') {
-            redirect(base_url().'offices/qa');
-		} else if ($route == 'export') {
-			$this->load->view('export');
-		} else if ($route == 'user') {
-			$this->load->view('user');
-		} else {
-			$this->index($route);
-		}
-
-	}
-
-
-	public function merge() {
-		$this->load->view('merge');
-	}
-
-
-
 }
-
-/* End of file welcome.php */
-/* Location: ./application/controllers/welcome.php */

--- a/application/controllers/Docs.php
+++ b/application/controllers/Docs.php
@@ -65,21 +65,7 @@ class Docs extends CI_Controller {
 	public function routes($route = 'intro') {
 
 		if ($route == 'intro') {
-            if ($this->input->method(TRUE) == 'HEAD') {
-				// If the HTTP method was HEAD CodeIgniter 3.1.* will return a
-				// 303 status. That's bad because our load-balancer doesn't
-				// understand a 303 to mean "healthy". So here we're explicitly
-				// returning a 302 the same way a GET would to keep the
-				// load-balancer happy.
-
-				// This is a temporary fix until BSP's load-balancer explicitly
-				// checks our new /healthcheck endpoint instead of this
-				// endpoint.
-				$this->output->set_status_header(302, 'Hello Mister Load Balancer Sir');
-				redirect(base_url().'offices/qa', 'auto', 302);
-			} else {
             redirect(base_url().'offices/qa');
-			}
 		} else if ($route == 'export') {
 			$this->load->view('export');
 		} else if ($route == 'user') {

--- a/application/controllers/Export.php
+++ b/application/controllers/Export.php
@@ -1,0 +1,23 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Export extends CI_Controller {
+
+
+	function __construct() {
+		parent::__construct();
+
+		$this->load->helper('url');
+		$this->load->helper('api');
+
+	}
+
+
+	/**
+	 * Index Page for this controller.
+	 */
+	public function index()
+	{
+		$this->load->view('export');
+	}
+
+}

--- a/application/controllers/Merge.php
+++ b/application/controllers/Merge.php
@@ -1,0 +1,23 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Merge extends CI_Controller {
+
+
+	function __construct() {
+		parent::__construct();
+
+		$this->load->helper('url');
+		$this->load->helper('api');
+
+	}
+
+
+	/**
+	 * Index Page for this controller.
+	 */
+	public function index()
+	{
+		$this->load->view('merge');
+	}
+
+}

--- a/application/controllers/Offices.php
+++ b/application/controllers/Offices.php
@@ -381,24 +381,20 @@ class Offices extends CI_Controller {
 
 	}
 
-	public function routes($route, $parameter1 = null, $parameter2 = null, $parameter3 = null, $parameter4 = null) {
+    public function all() {
+        return $this->index($milestone=null, $output=null, $show_all_offices = true);
+    }
 
-		if($route == 'all') {
-			return $this->index($milestone=null, $output=null, $show_all_offices = true);
-		}
+    public function qa() {
+        $this->load->model('campaign_model', 'campaign');
+        $milestones = $this->campaign->milestones_model();
+        $milestone 	= $this->campaign->milestone_filter(null, $milestones);
 
-		if($route == 'detail') {
-			return $this->detail($parameter1, $parameter2, $parameter3, $parameter4);
-		}
+        return $this->index($milestone=$milestone->current, $output=null, $show_all_offices=true, $show_all_fields=false, $show_qa_fields=true);
 
-		if($route == 'qa') {
+    }
 
-			$this->load->model('campaign_model', 'campaign');
-			$milestones = $this->campaign->milestones_model();
-			$milestone 	= $this->campaign->milestone_filter(null, $milestones);
-
-			return $this->index($milestone=$milestone->current, $output=null, $show_all_offices=true, $show_all_fields=false, $show_qa_fields=true);
-		}
+    public function milestone($route, $parameter1 = null, $parameter2 = null, $parameter3 = null, $parameter4 = null) {
 
 		// check if it's a milestone date
     	$d = DateTime::createFromFormat('Y-m-d', $route);
@@ -421,7 +417,6 @@ class Offices extends CI_Controller {
     		} else {
     			$show_qa_fields = false;
     		}
-
 
     		return $this->index($milestone=$route, $output=null, $show_all_offices, $show_all_fields, $show_qa_fields);
     	}

--- a/application/tests/controllers/API_test.php
+++ b/application/tests/controllers/API_test.php
@@ -9,7 +9,7 @@ class ApiTest extends TestCase
      * We could ignore __construct, but since CodeIgniter filters that method out anyway its OK to include it.
      */
     public function testOnlyExpectedControllerMethodsAreExposed() {
-        $expected_public_methods = '{"Campaign":["__construct","index","convert","csv_to_json","csv_field_mapper","schema_map_filter","csv","digitalstrategy","status","status_review_update","status_update","validate","upgrade_schema","get_instance"],"Docs":["__construct","index","routes","merge","get_instance"],"Healthcheck":["index","__construct","get_instance"],"Import":["__construct","index","tracker","match_agency_slugs","match_bureaus","get_instance"],"Migrate":["__construct","index","get_instance"],"Offices":["__construct","index","export","detail","routes","get_instance"],"Welcome":["index","__construct","get_instance"]}';
+        $expected_public_methods = '{"Campaign":["__construct","index","convert","csv_to_json","csv_field_mapper","schema_map_filter","csv","digitalstrategy","status","status_review_update","status_update","validate","upgrade_schema","get_instance"],"Docs":["__construct","index","get_instance"],"Export":["__construct","index","get_instance"],"Healthcheck":["index","__construct","get_instance"],"Import":["__construct","index","tracker","match_agency_slugs","match_bureaus","get_instance"],"Merge":["__construct","index","get_instance"],"Migrate":["__construct","index","get_instance"],"Offices":["__construct","index","export","detail","all","qa","milestone","get_instance"],"Welcome":["index","__construct","get_instance"]}';
 
         $public_methods = array();
         $controllerFiles = glob(APPPATH.'controllers/*.php');

--- a/documentation/about.md
+++ b/documentation/about.md
@@ -8,7 +8,7 @@ The Project Open Data Dashboard is informed by [M-13-13](https://project-open-da
 
  1.	Quarterly review by OMB staff of Leading Indicators in six categories: Enterprise Data Inventory, Public Data Listing, Public Engagement, Privacy & Security, Human Capital, and Use & Impact. For more information see [Leading Indicators Strategy Rubric](./rubric).  
 
- 2.	Automated metrics determined by a script that analyzes [agency.gov] /data.json, /digitalstrategy.json, and /data files every 24 hours until the end of the quarter when a historic snapshot is generated. For more information see [Documentation](./main).   
+ 2.	Automated metrics determined by a script that analyzes agency.gov /data.json, /digitalstrategy.json, and /data files every 24 hours until the end of the quarter when a historic snapshot is generated. For more information see [Documentation](./main).   
 
 ### Open Source 
 The Project Open Data Dashboard is an open source project. Some ways you can contribute are: by reporting bugs, by suggesting new features, by translating content to a new language, by writing or editing documentation, by writing specifications, by writing code and documentation (no pull request is too small: fix typos, add code comments, clean up inconsistent whitespace), by reviewing pull requests, and by closing issues. Before contributing, we encourage you to read our CONTRIBUTING guide, our LICENSE, and our README.


### PR DESCRIPTION
Addresses https://github.com/GSA/datagov-deploy/issues/1769

* Pull docs only from files that exist in the local deployment
* Remove shim that redirected to the /healthcheck endpoint now that the load-balancer checks it directly
* Routing refactor:
  * `/` maps directly to `Offices->qa()`, rather than going through Docs->routes('intro') (also removes the "default redirect" 
for the base of the app)
  * `/docs/[anypage]` now routes to Docs->index([anypage])
  * `/export` maps directly to `Export->indexI()` (a new Controller) rather than going through `Docs->routes('export')`
  * `/merge` maps directly to `Merge->index()` (a new Controller) rather than going through `Docs->merge()`
  * `/offices/all` maps directly to `Offices->all()` rather than going through `Offices->routes('qa')`
  * `/offices/qa` maps directly to `Offices->qa()` rather than going through `Offices->routes('qa')`
  * `/offices/[Date]` maps directly to `Offices->milestone([date])` rather than going through `Offices->routes('[date]')`
  * `/account` was vestigial and is removed
  * `/logout` was vestigial and is removed
  * `/docs/user` was vestigial and is removed
  * `/docs/export` was vestigial and is removed
  * `/docs/intro` was vestigial and is removed
* Remove stray brackets from about page