### PR TITLE
Prevent build errors from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python
+    steps:
+      - run:
+          name: N/A
+          command: |
+            echo See GitHub actions for CI.
+            echo ok


### PR DESCRIPTION
We're still using CircleCI, just not on this branch. Let's leave a noop build config to avoid our commits getting marked as errored.