### PR TITLE
Move 1 minute to avoid space issues

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -3,7 +3,7 @@ name: restart application
 
 on:
   schedule:
-    - cron: '13/15 * * * *'
+    - cron: '14/15 * * * *'
 
 jobs:
   restart-staging:


### PR DESCRIPTION
Move 1 minute to avoid issue with restart failures due to running out of space (randomly occurring).