### PR TITLE
Bring Navy name update change from FCS to main

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -69,7 +69,7 @@ $config['migration_auto_latest'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 12;
+$config['migration_version'] = 13;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/013_fix_navy_name.php
+++ b/application/migrations/013_fix_navy_name.php
@@ -1,0 +1,18 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_fix_navy_name extends CI_Migration
+{
+
+    public function up()
+    {
+        // Update Navy's name
+        $this->db->query('UPDATE offices SET name = "U.S. Navy" WHERE id = "49561"');
+    }
+
+    public function down()
+    {
+      $this->db->query('UPDATE offices SET name = "Navy" WHERE id = "49561"');
+    }
+}


### PR DESCRIPTION
updates "Navy" to "U.S. Navy"

This change is migration 13 on main, while it was migration 12 on fcs (because it was never migrated back, and meanwhile main got a different migration 12).