### PR TITLE
Fix private range bitmask

### DIFF
--- a/application/helpers/api_helper.php
+++ b/application/helpers/api_helper.php
@@ -34,7 +34,6 @@ namespace APIHelper {
             // ...or unresolvable hostnames
             $resolved = dns_get_record($host.".", DNS_A + DNS_AAAA);
             if (!$resolved) {
-                echo "Host $host is UNRESOLVED!";
                 return false;
             }
 
@@ -67,7 +66,7 @@ namespace APIHelper {
                     if (IpUtils::checkIp6($resolved[$i]["ipv6"], '::ffff:10.0.0.0/104')     ||  // 10.0.0.0/8
                         IpUtils::checkIp6($resolved[$i]["ipv6"], '::ffff:172.16.0.0/108')   ||  // 172.16.0.0/12
                         IpUtils::checkIp6($resolved[$i]["ipv6"], '::ffff:192.168.0.0/112')  ||  // 192.168.0.0/16
-                        IpUtils::checkIp6($resolved[$i]["ipv6"], '::ffff:127.0.0.1/128')) {     // 127.0.0.1/32
+                        IpUtils::checkIp6($resolved[$i]["ipv6"], '::ffff:127.0.0.1/104')) {     // 127.0.0.1/8
                         return false;
                     }
 

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -71,7 +71,7 @@ switch (ENVIRONMENT)
 {
 	case 'testing':
 	case 'development':
-		error_reporting(-1);
+		error_reporting(E_ALL);
 		ini_set('display_errors', 1);
 	break;
 

--- a/application/tests/helpers/api_helper_test.php
+++ b/application/tests/helpers/api_helper_test.php
@@ -163,6 +163,7 @@ class APIHelperTest extends TestCase
         $badRedirects["localhost2.ip6"] = array("http://localhost2.ip6:80", [['type' => 'AAAA', 'ipv6' => '::ffff:127.0.0.1']]);
         $badRedirects["private1.ip6"] = array("https://private1.ip6:80", [['type' => 'AAAA', 'ipv6' => '::ffff:192.168.1.18']]);
         $badRedirects["private2.ip6"] = array("https://private2.ip6:80", [['type' => 'AAAA', 'ipv6' => '::ffff:10.0.0.1']]);
+        $badRedirects["private3.ip6"] = array("http://private3.ip6:80", [['type' => 'AAAA', 'ipv6' => '::ffff:127.0.0.2']]);
 
         // Domains that resolve to IPv6 link-local adddresses? Hell no!
         $badRedirects["linklocal.ip6"] = array("https://linklocal.ip6/", [['type' => 'AAAA', 'ipv6' => 'fe80::']]);


### PR DESCRIPTION
The prior prefix version specified only a single IP, when we really wanted the 24-bit 127.x.x.x range.

(ports the fix to the FCS branch)