### PR TITLE
Automate dashboard crawl commands

### DIFF
--- a/.github/workflows/crawl-long.yml
+++ b/.github/workflows/crawl-long.yml
@@ -3,8 +3,8 @@ name: Dashboard crawl-long
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '30 12 1 1,4,7,10 *'
+  # schedule:
+  #   - cron: '30 12 1 1,4,7,10 *'
 
 jobs:
   dashboard-crawl-long-staging:

--- a/.github/workflows/crawl-long.yml
+++ b/.github/workflows/crawl-long.yml
@@ -1,0 +1,39 @@
+---
+name: Dashboard crawl-long
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 12 1 1,4,7,10 *'
+
+jobs:
+  dashboard-crawl-long-staging:
+    name: dashboard crawl (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: crawl-long
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: run-task dashboard-stage --command "php public/index.php campaign status long-running full-scan"
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+  dashboard-crawl-long-prod:
+    name: dashboard crawl (production)
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: crawl-long
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: run-task dashboard-stage --command "php public/index.php campaign status long-running full-scan"
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -3,8 +3,8 @@ name: Dashboard crawl (daily)
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '15 4 * * *'
+  # schedule:
+  #   - cron: '15 4 * * *'
 
 jobs:
   dashboard-crawl-staging:

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -17,7 +17,7 @@ jobs:
       - name: crawl download
         uses: usds/cloud-gov-cli@master
         with:
-          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download"
+          command: run-task dashboard-stage --wait --command "php public/index.php campaign status omb-monitored download"
           org: gsa-datagov
           space: staging
           user: ${{secrets.CF_SERVICE_USER}}
@@ -25,7 +25,7 @@ jobs:
       - name: crawl full scan
         uses: usds/cloud-gov-cli@master
         with:
-          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan"
+          command: run-task dashboard-stage --wait --command "php public/index.php campaign status omb-monitored full-scan"
           org: gsa-datagov
           space: staging
           user: ${{secrets.CF_SERVICE_USER}}
@@ -40,7 +40,7 @@ jobs:
       - name: crawl download
         uses: usds/cloud-gov-cli@master
         with:
-          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download"
+          command: run-task dashboard-stage --wait --command "php public/index.php campaign status omb-monitored download"
           org: gsa-datagov
           space: prod
           user: ${{secrets.CF_SERVICE_USER}}
@@ -48,7 +48,7 @@ jobs:
       - name: crawl full scan
         uses: usds/cloud-gov-cli@master
         with:
-          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan"
+          command: run-task dashboard-stage --wait --command "php public/index.php campaign status omb-monitored full-scan"
           org: gsa-datagov
           space: prod
           user: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -1,0 +1,55 @@
+---
+name: Dashboard crawl (daily)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 4 * * *'
+
+jobs:
+  dashboard-crawl-staging:
+    name: dashboard crawl (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: crawl download
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download"
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: crawl full scan
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan"
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+  dashboard-crawl-prod:
+    name: dashboard crawl (production)
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: crawl download
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download"
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: crawl full scan
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan"
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}


### PR DESCRIPTION
Utilizes the same commands implemented on fcs
Similar timing.

Pulled from [current cron setup](https://github.com/GSA/datagov-deploy-dashboard/blob/master/tasks/deploy.yml#L65-L98) and current [supervisor config](https://github.com/GSA/datagov-deploy-dashboard/blob/master/templates/etc_supervisor_conf.d_dashboard.conf.j2).