### PR TITLE
Use public s3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Assuming you're logged in for the Cloud Foundry CLI, Run the following commands 
 ```sh
 $ cf create-service aws-rds small-mysql-redundant ${app_name}-db
 
-$ cf create-service s3 basic ${app_name}-s3
+$ cf create-service s3 basic-public ${app_name}-s3
 
 $ cf create-user-provided-service ${app_name}-secrets -p '{
   "ENCRYPTION_KEY": "long-random-string"

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ default_config: &defaults
   timeout: 180
   services:
     - ((app_name))-db       # cf create-service aws-rds small-mysql-redundant dashboard-db
-    - ((app_name))-s3       # cf create-service s3 basic dashboard-s3
+    - ((app_name))-s3       # cf create-service s3 basic-public dashboard-s3
     - ((app_name))-secrets  # cf create-user-provided-service dashboard-secrets -p '{
                # "ENCRYPTION_KEY": "long-random-string"
                # }'


### PR DESCRIPTION
Dashboard does not proxy s3 objects for users, the s3 bucket must be publicly
accessible.
