### PR TITLE
Fix crawls

### DIFF
--- a/.github/workflows/crawl-long.yml
+++ b/.github/workflows/crawl-long.yml
@@ -15,10 +15,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: crawl download
-        # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf run-task dashboard-stage --command "php public/index.php campaign status long-running full-scan"
+          command: make cf-crawl-long-staging
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -32,10 +31,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: crawl download
-        # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf run-task dashboard --command "php public/index.php campaign status long-running full-scan"
+          command: make cf-crawl-long
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -19,7 +19,7 @@ jobs:
         # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
+          command: make cf-crawl-save-staging
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -28,7 +28,7 @@ jobs:
         # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
+          command: make cf-crawl-daily-staging
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -44,7 +44,7 @@ jobs:
         # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf run-task dashboard --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
+          command: make cf-crawl-save
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -53,7 +53,7 @@ jobs:
         # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf run-task dashboard --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
+          command: make cf-crawl-daily
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,18 @@ all: clean build install-dev-dependencies up test
 build:
 	docker-compose build
 
+cf-crawl-save-staging: cf run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
+
+cf-crawl-daily-staging: cf run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
+
+cf-crawl-long-staging: cf run-task dashboard-stage --command "php public/index.php campaign status long-running full-scan" --name dashboard-long-running-full-scan
+
+cf-crawl-save: cf run-task dashboard --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
+
+cf-crawl-daily: cf run-task dashboard --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
+
+cf-crawl-long: cf run-task dashboard --command "php public/index.php campaign status long-running full-scan" --name dashboard-long-running-full-scan
+
 cloud-test: build install-dev-dependencies up test
 
 clean:


### PR DESCRIPTION
See [latest failure](https://github.com/GSA/project-open-data-dashboard/actions/runs/1576176986)

Adds commands to makefile (considered script, wasn't worth overhead)
Then uses the make commands.
Cleans up various comments (we'll never use wait on long running, takes
longer than 6 hours that is the github action runner limit)