### PR TITLE
make is not included in image, use script

### DIFF
--- a/.github/workflows/crawl-long.yml
+++ b/.github/workflows/crawl-long.yml
@@ -17,7 +17,7 @@ jobs:
       - name: crawl download
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: make cf-crawl-long-staging
+          command: ./bin/cf-crawl-long.sh dashboard-stage
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -33,7 +33,7 @@ jobs:
       - name: crawl download
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: make cf-crawl-long
+          command: ./bin/cf-crawl-long.sh dashboard
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -15,20 +15,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: crawl download
+      - name: crawl daily (stage)
         # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: make cf-crawl-save-staging
-          cf_org: gsa-datagov
-          cf_space: staging
-          cf_username: ${{secrets.CF_SERVICE_USER}}
-          cf_password: ${{secrets.CF_SERVICE_AUTH}}
-      - name: crawl full scan
-        # pinned to cf7 until --wait is available for run-task on cf8...
-        uses: cloud-gov/cg-cli-tools@main
-        with:
-          command: make cf-crawl-daily-staging
+          command: ./bin/cf-crawl-daily.sh dashboard-stage
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -40,20 +31,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: crawl download
+      - name: crawl daily (prod)
         # pinned to cf7 until --wait is available for run-task on cf8...
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: make cf-crawl-save
-          cf_org: gsa-datagov
-          cf_space: prod
-          cf_username: ${{secrets.CF_SERVICE_USER}}
-          cf_password: ${{secrets.CF_SERVICE_AUTH}}
-      - name: crawl full scan
-        # pinned to cf7 until --wait is available for run-task on cf8...
-        uses: cloud-gov/cg-cli-tools@main
-        with:
-          command: make cf-crawl-daily
+          command: ./bin/cf-crawl-daily.sh dashboard
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/bin/cf-crawl-daily.sh
+++ b/bin/cf-crawl-daily.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+# To be executed with the app to use, ie ./cf-crawl-daily.sh dashboard-stage
+
+cf run-task "$1" --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
+
+cf run-task "$1" --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan

--- a/bin/cf-crawl-long.sh
+++ b/bin/cf-crawl-long.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+# To be executed with the app to use, ie ./cf-crawl-daily.sh dashboard-stage
+
+cf run-task "$1" --command "php public/index.php campaign status long-running full-scan" --name dashboard-long-running-full-scan


### PR DESCRIPTION
To fix #380 , previous implementation [failed](https://github.com/GSA/project-open-data-dashboard/actions/runs/1579922840)

Tested and confirmed to work locally.

It may be that the daily crawl will not always fully finish in the github 6 hour limit, but the task may succeed successfully. Will keep an eye on this, and if it makes too much noise may remove the --wait.