### PR TITLE
Remove --wait until cf8 bug is fixed

### DIFF
--- a/.github/workflows/crawl-long.yml
+++ b/.github/workflows/crawl-long.yml
@@ -15,7 +15,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: crawl download
-        uses: cloud-gov/cg-cli-tools@main
+        uses: cloud-gov/cg-cli-tools@cli-v7
         with:
           command: ./bin/cf-crawl-long.sh dashboard-stage
           cf_org: gsa-datagov
@@ -31,7 +31,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: crawl download
-        uses: cloud-gov/cg-cli-tools@main
+        uses: cloud-gov/cg-cli-tools@cli-v7
         with:
           command: ./bin/cf-crawl-long.sh dashboard
           cf_org: gsa-datagov

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: crawl daily (stage)
         # pinned to cf7 until --wait is available for run-task on cf8...
-        uses: cloud-gov/cg-cli-tools@main
+        uses: cloud-gov/cg-cli-tools@cli-v7
         with:
           command: ./bin/cf-crawl-daily.sh dashboard-stage
           cf_org: gsa-datagov
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
       - name: crawl daily (prod)
         # pinned to cf7 until --wait is available for run-task on cf8...
-        uses: cloud-gov/cg-cli-tools@main
+        uses: cloud-gov/cg-cli-tools@cli-v7
         with:
           command: ./bin/cf-crawl-daily.sh dashboard
           cf_org: gsa-datagov

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,6 @@ all: clean build install-dev-dependencies up test
 build:
 	docker-compose build
 
-cf-crawl-save-staging: cf run-task dashboard-stage --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
-
-cf-crawl-daily-staging: cf run-task dashboard-stage --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
-
-cf-crawl-long-staging: cf run-task dashboard-stage --command "php public/index.php campaign status long-running full-scan" --name dashboard-long-running-full-scan
-
-cf-crawl-save: cf run-task dashboard --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
-
-cf-crawl-daily: cf run-task dashboard --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
-
-cf-crawl-long: cf run-task dashboard --command "php public/index.php campaign status long-running full-scan" --name dashboard-long-running-full-scan
-
 cloud-test: build install-dev-dependencies up test
 
 clean:

--- a/bin/cf-crawl-daily.sh
+++ b/bin/cf-crawl-daily.sh
@@ -4,6 +4,6 @@ set -e
 
 # To be executed with the app to use, ie ./cf-crawl-daily.sh dashboard-stage
 
-cf run-task "$1" --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
+cf run-task "$1" --command "php public/index.php campaign status omb-monitored download" --name dashboard-omb-monitored-download
 
-cf run-task "$1" --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan
+cf run-task "$1" --command "php public/index.php campaign status omb-monitored full-scan" --name dashboard-omb-monitored-full-scan

--- a/bin/cf-crawl-daily.sh
+++ b/bin/cf-crawl-daily.sh
@@ -4,6 +4,6 @@ set -e
 
 # To be executed with the app to use, ie ./cf-crawl-daily.sh dashboard-stage
 
-cf run-task "$1" --command "php public/index.php campaign status omb-monitored download" --name dashboard-omb-monitored-download
+cf run-task "$1" --command "php public/index.php campaign status omb-monitored download" --wait --name dashboard-omb-monitored-download
 
-cf run-task "$1" --command "php public/index.php campaign status omb-monitored full-scan" --name dashboard-omb-monitored-full-scan
+cf run-task "$1" --command "php public/index.php campaign status omb-monitored full-scan" --wait --name dashboard-omb-monitored-full-scan


### PR DESCRIPTION
The daily jobs are failing. This cleans up a bunch of unnecessary code, and uses the cf-cliv7 per [this discussion](https://github.com/cloud-gov/cg-cli-tools/commit/8f5c57226d8f11a04b55bc863042a1389deba273#commitcomment-63895244).