### PR TITLE
Adjust memory quota

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -28,4 +28,5 @@ applications:
   processes:
   - type: web
     disk_quota: 512M
+    memory: ((memory_quota))
     timeout: 10

--- a/manifest.yml
+++ b/manifest.yml
@@ -29,4 +29,5 @@ applications:
   - type: web
     disk_quota: 512M
     memory: ((memory_quota))
+    instances: ((instances))
     timeout: 10

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -4,6 +4,7 @@ app_full_name: dashboard-dev
 
 # Number of application instances to run in cloud.gov
 instances: 1
+memory_quota: 64M
 
 # Routes to assign to this application. This must be globally unique within cloud.gov.
 routes:

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -5,6 +5,7 @@ app_full_name: dashboard
 
 # Number of application instances to run in cloud.gov
 instances: 2
+memory_quota: 128M
 
 # Routes to assign to this application. This must be globally unique within cloud.gov.
 routes:

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -4,6 +4,7 @@ app_full_name: dashboard-stage
 
 # Number of application instances to run in cloud.gov
 instances: 1
+memory_quota: 64M
 
 # Routes to assign to this application. This must be globally unique within cloud.gov.
 routes:


### PR DESCRIPTION
There's something happening with defaults in the manifest, but the deployed production has 512M of memory, so I don't think it's working; adding in the config where it might take effect.

![image](https://user-images.githubusercontent.com/85196563/150419236-f8992b70-f9d0-45a1-8b41-c3ac347afc6b.png)
