### PR TITLE
pinned alpine to 3.15

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # FROM php:7.3-alpine
-FROM alpine:3
+FROM alpine:3.15
 
 ENV ENVIRONMENT=development
 ENV DEFAULT_HOST=localhost:8000


### PR DESCRIPTION
experimented with 3.16, but it is missing php7+friends. on my machine the tests fail, but i believe for unrelated reasons as they also fail on alpine 3.11 (which was the last pinned version)

From [the last failed build](https://github.com/GSA/project-open-data-dashboard/runs/6716126053?check_suite_focus=true), mostly opening to start discussion after huddle with @btylerburton and @Jin-Sun-tts yesterday. 