### PR TITLE
removed dashboard route

### DIFF
--- a/vars.production.yml
+++ b/vars.production.yml
@@ -10,6 +10,5 @@ memory_quota: 512M
 # Routes to assign to this application. This must be globally unique within cloud.gov.
 routes:
   - route: dashboard-prod-datagov.app.cloud.gov
-  - route: dashboard.data.gov
 
 default_host: dashboard.data.gov


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4001 and https://github.com/GSA/data.gov/issues/4331. 

This PR will remove the `dashboard.data.gov` route from the dashboard app. In conjunction with https://github.com/GSA/datagov-website/pull/50, requests to dashboard will no longer be directed to dashboard, but to catalog `/dcat-us/validator` and `/reports`.

We probably want to merge https://github.com/GSA/datagov-website/pull/50 first, manually test the redirect is functioning correctly, then merge this.